### PR TITLE
Fix db directory creation error on Python 2.7

### DIFF
--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -1,5 +1,5 @@
-import os
 import errno
+import os
 
 from alembic.command import upgrade
 from alembic.config import Config

--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -1,5 +1,5 @@
 import os
-
+import errno
 
 from alembic.command import upgrade
 from alembic.config import Config
@@ -35,8 +35,13 @@ DB_SESSION = scoped_session(
 
 def create_db():
     """create_db."""
-    if not os.path.isdir(DB_FILE_DIR):
-        os.makedirs(DB_FILE_DIR, exist_ok=True)
+    try:
+        os.makedirs(DB_FILE_DIR)
+    except OSError as exception:
+        if exception.errno == errno.EEXIST and os.path.isdir(DB_FILE_DIR):
+            pass
+        else:
+            raise
     print('DB_FILE_PATH: ', DB_FILE_PATH)
 
 


### PR DESCRIPTION
ChainerUI wouldn't start on Python 2.7.x.

```bash
$ python --version
Python 2.7.12
$ chainerui db create
Traceback (most recent call last):
  File "/home/kuni/tmp/chaineruitest/bin/chainerui", line 11, in <module>
    sys.exit(main())
  File "/home/kuni/tmp/chaineruitest/local/lib/python2.7/site-packages/chainerui/app.py", line 105, in main
    args.handler(args)
  File "/home/kuni/tmp/chaineruitest/local/lib/python2.7/site-packages/chainerui/app.py", line 28, in db_handler
    create_db()
  File "/home/kuni/tmp/chaineruitest/local/lib/python2.7/site-packages/chainerui/__init__.py", line 39, in create_db
    os.makedirs(DB_FILE_DIR, exist_ok=True)
TypeError: makedirs() got an unexpected keyword argument 'exist_ok'
```

The argument `exist_ok=True` of `os.makedirs` is supported by only `Python>=3.5`.
So I rewrote the `create_db` function without this argument.
