### PR TITLE
Pass dict type conditions to save_args

### DIFF
--- a/chainerui/utils/save_args.py
+++ b/chainerui/utils/save_args.py
@@ -18,6 +18,8 @@ def save_args(conditions, out_path):
 
     if isinstance(conditions, argparse.Namespace):
         args = vars(conditions)
+    else:
+        args = conditions
     args_dict = {k: str(v) for k, v in args.items()}
 
     try:


### PR DESCRIPTION
I encountered the following error when using dict as conditions.
```
  File "/Users/shinsuke.sugaya/.anyenv/envs/pyenv/versions/3.6.3/lib/python3.6/site-packages/chainerui/utils/save_args.py", line 21, in save_args
    args_dict = {k: str(v) for k, v in args.items()}
UnboundLocalError: local variable 'args' referenced before assignment
```