### PR TITLE
Log report util class to support train loop without Trainer

### DIFF
--- a/chainerui/utils/__init__.py
+++ b/chainerui/utils/__init__.py
@@ -1,4 +1,5 @@
 from chainerui.utils.command_item import CommandItem  # NOQA
 from chainerui.utils.is_jsonable import is_jsonable  # NOQA
 from chainerui.utils.is_numberable import is_numberable  # NOQA
+from chainerui.utils.log_report import LogReport  # NOQA
 from chainerui.utils.save_args import save_args  # NOQA

--- a/chainerui/utils/log_report.py
+++ b/chainerui/utils/log_report.py
@@ -1,0 +1,28 @@
+import json
+import os
+import shutil
+import tempfile
+
+from chainerui.utils.save_args import save_args
+
+
+class LogReport(object):
+
+    def __init__(self, out_path, conditions=None):
+        self._out_path = out_path
+        self._log_name = 'log'
+        self._log = []
+
+        if conditions is not None:
+            # if not exist the path, `save_args` makes it
+            save_args(conditions, out_path)
+
+    def __call__(self, stats):
+        self._log.append(stats)
+
+        fd, path = tempfile.mkstemp(prefix=self._log_name, dir=self._out_path)
+        with os.fdopen(fd, 'w') as f:
+            json.dump(self._log, f, indent=4)
+
+        new_path = os.path.join(self._out_path, self._log_name)
+        shutil.move(path, new_path)

--- a/chainerui/utils/log_report.py
+++ b/chainerui/utils/log_report.py
@@ -3,21 +3,46 @@ import os
 import shutil
 import tempfile
 
+from chainer.training.trainer import _get_time
+
 from chainerui.utils.save_args import save_args
 
 
 class LogReport(object):
 
-    def __init__(self, out_path, conditions=None):
+    """Util class to output 'log' file.
+
+    This class supports to output 'log' file. The file spec follows
+    :class:`chainer.extensions.LogReport`, however, 'epoch' and 'iteration'
+    are not set automatically, and need to set these values.
+
+    Args:
+        out_path (str): Output directory name to save conditions.
+        conditions (:class:`argparse.Namespace` or dict): Experiment conditions
+            to show on a job table. Keys are show as table header and values
+            are show at a job row.
+        elapsed_time_flag (bool): This class calculates elapsed time
+            automatically. The measurement starts when call as new instance.
+            If a target train loop has original elapsed time, then set the
+            flag as `False` and set the time manually.
+
+    """
+
+    def __init__(self, out_path, conditions=None, elapsed_time_flag=True):
         self._out_path = out_path
         self._log_name = 'log'
         self._log = []
+        self._start_at = None
 
         if conditions is not None:
             # if not exist the path, `save_args` makes it
             save_args(conditions, out_path)
+        if elapsed_time_flag:
+            self._start_at = _get_time()
 
     def __call__(self, stats):
+        if self._start_at is not None:
+            stats['elapsed_time'] = _get_time() - self._start_at
         self._log.append(stats)
 
         fd, path = tempfile.mkstemp(prefix=self._log_name, dir=self._out_path)

--- a/chainerui/utils/log_report.py
+++ b/chainerui/utils/log_report.py
@@ -21,27 +21,34 @@ class LogReport(object):
         conditions (:class:`argparse.Namespace` or dict): Experiment conditions
             to show on a job table. Keys are show as table header and values
             are show at a job row.
-        elapsed_time_flag (bool): This class calculates elapsed time
-            automatically. The measurement starts when call as new instance.
-            If a target train loop has original elapsed time, then set the
-            flag as `False` and set the time manually.
 
     """
 
-    def __init__(self, out_path, conditions=None, elapsed_time_flag=True):
+    def __init__(self, out_path, conditions=None):
         self._out_path = out_path
         self._log_name = 'log'
         self._log = []
-        self._start_at = None
+        self._start_at = _get_time()
 
         if conditions is not None:
             # if not exist the path, `save_args` makes it
             save_args(conditions, out_path)
-        if elapsed_time_flag:
-            self._start_at = _get_time()
+        else:
+            try:
+                os.makedirs(out_path)
+            except OSError:
+                pass
 
     def __call__(self, stats):
-        if self._start_at is not None:
+        """Add training log.
+
+        Args:
+            stats (dict): Training log values. The object must be key-value
+                style and values type must be `float` or `int`. When the object
+                does not have 'elapsed_time' key, the function set the time
+                automatically. The measurement starts when create new instance.
+        """
+        if 'elapsed_time' not in stats:
             stats['elapsed_time'] = _get_time() - self._start_at
         self._log.append(stats)
 

--- a/examples/train_mnist_custom_loop.py
+++ b/examples/train_mnist_custom_loop.py
@@ -67,7 +67,7 @@ def main():
     sum_loss = 0
 
     # [ChainerUI] setup log reporter to show on ChainerUI
-    ui_report = LogReport(args.out, args)
+    ui_report = LogReport(args.out, conditions=args)
     while train_iter.epoch < args.epoch:
         batch = train_iter.next()
         x_array, t_array = convert.concat_examples(batch, args.gpu)
@@ -79,13 +79,10 @@ def main():
 
         if train_iter.is_new_epoch:
             print('epoch: ', train_iter.epoch)
+            train_loss = sum_loss / train_count
+            train_accuracy = sum_accuracy / train_count
             print('train mean loss: {}, accuracy: {}'.format(
-                sum_loss / train_count, sum_accuracy / train_count))
-            # [ChainerUI] collect log information
-            stats = {}
-            stats['epoch'] = train_iter.epoch
-            stats['train/loss'] = sum_loss / train_count
-            stats['train/accuracy'] = sum_accuracy / train_count
+                train_loss, train_accuracy))
 
             # evaluation
             sum_accuracy = 0
@@ -99,11 +96,17 @@ def main():
                 sum_accuracy += float(model.accuracy.data) * len(t.data)
 
             test_iter.reset()
+            test_loss = sum_loss / test_count
+            test_accuracy = sum_accuracy / test_count
             print('test mean  loss: {}, accuracy: {}'.format(
-                sum_loss / test_count, sum_accuracy / test_count))
-            stats['test/loss'] = sum_loss / test_count
-            stats['test/accuracy'] = sum_accuracy / test_count
-            # [ChainerUI] write to 'log' file
+                test_loss, test_accuracy))
+            # [ChainerUI] write values to 'log' file
+            stats = {
+                'epoch': train_iter.epoch,
+                'iteration': train_iter.epoch * args.batchsize,
+                'train/loss': train_loss, 'train/accuracy': train_accuracy,
+                'test/loss': test_loss, 'test/accuracy': test_accuracy
+                }
             ui_report(stats)
             sum_accuracy = 0
             sum_loss = 0

--- a/examples/train_mnist_custom_loop.py
+++ b/examples/train_mnist_custom_loop.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""Fully-connected neural network example using MNIST dataset
+
+This code is a custom loop version of train_mnist.py. That is, we train
+models without using the Trainer class in chainer and instead write a
+training loop that manually computes the loss of minibatches and
+applies an optimizer to update the model.
+"""
+from __future__ import print_function
+
+import argparse
+
+import chainer
+from chainer.dataset import convert
+import chainer.links as L
+from chainer import serializers
+
+from chainerui.utils import LogReport
+
+import train_mnist
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Chainer example: MNIST')
+    parser.add_argument('--batchsize', '-b', type=int, default=100,
+                        help='Number of images in each mini-batch')
+    parser.add_argument('--epoch', '-e', type=int, default=20,
+                        help='Number of sweeps over the dataset to train')
+    parser.add_argument('--gpu', '-g', type=int, default=-1,
+                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--out', '-o', default='result',
+                        help='Directory to output the result')
+    parser.add_argument('--resume', '-r', default='',
+                        help='Resume the training from snapshot')
+    parser.add_argument('--unit', '-u', type=int, default=1000,
+                        help='Number of units')
+    args = parser.parse_args()
+
+    print('GPU: {}'.format(args.gpu))
+    print('# unit: {}'.format(args.unit))
+    print('# Minibatch-size: {}'.format(args.batchsize))
+    print('# epoch: {}'.format(args.epoch))
+    print('')
+
+    # Set up a neural network to train
+    model = L.Classifier(train_mnist.MLP(args.unit, 10))
+    if args.gpu >= 0:
+        # Make a speciied GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()
+        model.to_gpu()  # Copy the model to the GPU
+
+    # Setup an optimizer
+    optimizer = chainer.optimizers.Adam()
+    optimizer.setup(model)
+
+    # Load the MNIST dataset
+    train, test = chainer.datasets.get_mnist()
+
+    train_count = len(train)
+    test_count = len(test)
+
+    train_iter = chainer.iterators.SerialIterator(train, args.batchsize)
+    test_iter = chainer.iterators.SerialIterator(test, args.batchsize,
+                                                 repeat=False, shuffle=False)
+
+    sum_accuracy = 0
+    sum_loss = 0
+
+    # [ChainerUI] setup log reporter to show on ChainerUI
+    ui_report = LogReport(args.out, args)
+    while train_iter.epoch < args.epoch:
+        batch = train_iter.next()
+        x_array, t_array = convert.concat_examples(batch, args.gpu)
+        x = chainer.Variable(x_array)
+        t = chainer.Variable(t_array)
+        optimizer.update(model, x, t)
+        sum_loss += float(model.loss.data) * len(t.data)
+        sum_accuracy += float(model.accuracy.data) * len(t.data)
+
+        if train_iter.is_new_epoch:
+            print('epoch: ', train_iter.epoch)
+            print('train mean loss: {}, accuracy: {}'.format(
+                sum_loss / train_count, sum_accuracy / train_count))
+            # [ChainerUI] collect log information
+            stats = {}
+            stats['epoch'] = train_iter.epoch
+            stats['train/loss'] = sum_loss / train_count
+            stats['train/accuracy'] = sum_accuracy / train_count
+
+            # evaluation
+            sum_accuracy = 0
+            sum_loss = 0
+            for batch in test_iter:
+                x_array, t_array = convert.concat_examples(batch, args.gpu)
+                x = chainer.Variable(x_array)
+                t = chainer.Variable(t_array)
+                loss = model(x, t)
+                sum_loss += float(loss.data) * len(t.data)
+                sum_accuracy += float(model.accuracy.data) * len(t.data)
+
+            test_iter.reset()
+            print('test mean  loss: {}, accuracy: {}'.format(
+                sum_loss / test_count, sum_accuracy / test_count))
+            stats['test/loss'] = sum_loss / test_count
+            stats['test/accuracy'] = sum_accuracy / test_count
+            # [ChainerUI] write to 'log' file
+            ui_report(stats)
+            sum_accuracy = 0
+            sum_loss = 0
+
+    # Save the model and the optimizer
+    print('save the model')
+    serializers.save_npz('mlp.model', model)
+    print('save the optimizer')
+    serializers.save_npz('mlp.state', optimizer)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/utils_tests/test_log_report.py
+++ b/tests/utils_tests/test_log_report.py
@@ -1,0 +1,68 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from chainerui.utils import log_report
+
+
+class TestLogReport(unittest.TestCase):
+
+    def setUp(self):
+        self._dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if os.path.exists(self._dir):
+            shutil.rmtree(self._dir)
+
+    def test_add_log_without_elapsed_time(self):
+        test_dir = os.path.join(self._dir, 'result')
+        target = log_report.LogReport(test_dir, {'batchsize': 100})
+        assert os.path.exists(test_dir)
+        assert os.path.exists(os.path.join(test_dir, 'args'))
+
+        log = {'epoch': 1, 'iteration': 100, 'loss': 0.1}
+        target(log)
+        log_path = os.path.join(test_dir, 'log')
+        assert os.path.exists(log_path)
+
+        with open(log_path) as f:
+            target_log = json.load(f)
+        assert len(target_log) == 1
+        target_log0 = target_log[0]
+        assert target_log0['epoch'] == 1
+        assert target_log0['iteration'] == 100
+        assert target_log0['loss'] - 0.1 < 1e-10
+        assert 'elapsed_time' in target_log0
+
+        log2 = {'epoch': 10, 'iteration': 1000, 'loss': 0.001}
+        target(log2)
+        with open(log_path) as f:
+            target_log = json.load(f)
+        assert len(target_log) == 2
+        target_log1 = target_log[1]
+        assert target_log1['epoch'] == 10
+        assert target_log1['iteration'] == 1000
+        assert target_log1['loss'] - 0.001 < 1e-10
+        assert target_log1['elapsed_time'] > 0
+
+    def test_add_log_with_elapsed_time(self):
+        test_dir = os.path.join(self._dir, 'result2')
+        target = log_report.LogReport(test_dir)
+        assert os.path.exists(test_dir)
+        assert not os.path.exists(os.path.join(test_dir, 'args'))
+
+        log = {'epoch': 1, 'iteration': 100, 'loss': 0.1, 'elapsed_time': 150}
+        target(log)
+        log_path = os.path.join(test_dir, 'log')
+        assert os.path.exists(log_path)
+
+        with open(log_path) as f:
+            target_log = json.load(f)
+        assert len(target_log) == 1
+        target_log0 = target_log[0]
+        assert target_log0['epoch'] == 1
+        assert target_log0['iteration'] == 100
+        assert target_log0['loss'] - 0.1 < 1e-10
+        assert target_log0['elapsed_time'] == 150


### PR DESCRIPTION
refs #27 

- the util class set 'elapsed_time' automatically, but 'epoch' and 'iteration' is not set.
- example code is based on [train_mnist_custom_loop.py](chainer/examples/mnist/train_mnist_custom_loop.py)