### PR TITLE
Workaround for pallets/flask#2193

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ chainerui_dependencies: &chainerui_dependencies
     name: install dependencies
     command: |
       . venv/bin/activate
-      pip install werkzeug==0.12.2
       pip install numpy==1.13.1
       pip install chainer==v3.1.0
       pip install autopep8 hacking

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask>=0.12.2
+Werkzeug<0.13
 APScheduler>=3.3.1
 sqlalchemy>=1.1.14
 alembic>=0.9.5


### PR DESCRIPTION
If Flask that includes pallets/flask#2193 is released, this PR isn't need to merged.