### PR TITLE
Hide "Invalid Date"

### DIFF
--- a/frontend/src/components/result/Commands.jsx
+++ b/frontend/src/components/result/Commands.jsx
@@ -12,13 +12,14 @@ const createCommandRowElems = (commands) => commands.sort((a, b) =>
   const request = command.request || {};
   const response = command.response || {};
   const { schedule } = request;
+  const { executed_at: executedAt } = response;
   return (
     <tr className="command-row" key={command.id}>
       <td>{command.name}</td>
       <td>{responseStatusToIcon(response.status)}</td>
       <td>{(new Date(request.created_at)).toLocaleString()}</td>
       <td>{schedule ? `${schedule.value} ${schedule.key}` : ''}</td>
-      <td>{(new Date(response.executed_at)).toLocaleString()}</td>
+      <td>{executedAt ? (new Date(executedAt)).toLocaleString() : ''}</td>
       <td>{response.epoch}</td>
       <td>{response.iteration}</td>
       <td>{response.elapsed_time != null ? response.elapsed_time.toFixed(2) : ''}</td>


### PR DESCRIPTION
Fix #7.

I hid `executed_at` that is empty instead of replacing to "Waiting".

As the reason:
* The user can know the status in response status field.
* The message is difficult because the status gets "before scheduling" or "after scheduling". 

Before:
![2018-01-15 16 02 49](https://user-images.githubusercontent.com/280562/34931061-08df2a04-fa10-11e7-9c9e-40f303336716.png)

After:
![2018-01-15 16 03 51](https://user-images.githubusercontent.com/280562/34931067-108ca6b4-fa10-11e7-80e2-076d87302ab8.png)