### PR TITLE
[WIP] Commands are executed only when training job is running

### DIFF
--- a/chainerui/extensions/commands_extension.py
+++ b/chainerui/extensions/commands_extension.py
@@ -6,6 +6,7 @@ from chainer.training.triggers import IntervalTrigger
 import six
 
 from chainerui.utils.command_item import CommandItem
+from chainerui.utils.commands_state import CommandsState
 
 
 def shouldExecute(trainer, command):
@@ -139,8 +140,12 @@ class CommandsExtension(extension.Extension):
         self._receivers = self.default_receivers.copy()
         self._receivers.update(receivers)
 
+        self._out = ''
+
     def initialize(self, trainer):
+        self._out = trainer.out
         CommandItem.remove_commands_file(trainer.out)
+        CommandsState.run(trainer)
         if isinstance(trainer.stop_trigger, IntervalTrigger):
             trainer.stop_trigger = _CommandIntervalTrigger(
                 trainer.stop_trigger)
@@ -167,7 +172,8 @@ class CommandsExtension(extension.Extension):
             CommandItem.dump_commands(commands, trainer.out)
 
     def finalize(self):
-        pass
+        if self._out != '':
+            CommandsState.stop(self._out)
 
     def add_receiver(self, command_name, function):
         if command_name is None:

--- a/chainerui/utils/__init__.py
+++ b/chainerui/utils/__init__.py
@@ -1,4 +1,6 @@
 from chainerui.utils.command_item import CommandItem  # NOQA
+from chainerui.utils.commands_state import CommandsState  # NOQA
+from chainerui.utils.commands_state import JobStatus  # NOQA
 from chainerui.utils.is_jsonable import is_jsonable  # NOQA
 from chainerui.utils.is_numberable import is_numberable  # NOQA
 from chainerui.utils.log_report import LogReport  # NOQA

--- a/chainerui/utils/commands_state.py
+++ b/chainerui/utils/commands_state.py
@@ -17,6 +17,12 @@ class JobStatus(Enum):
         return self.name.lower()
 
 
+def _job_status_converter(o):
+    if isinstance(o, JobStatus):
+        return str(o)
+    # pass other types to raise default exception
+
+
 class CommandsState(object):
 
     _default_filename = '.chainerui_commands'
@@ -68,11 +74,6 @@ class CommandsState(object):
         fd, path = tempfile.mkstemp(
             prefix=cls._default_filename, dir=out_path)
         with os.fdopen(fd, 'w') as f:
-            json.dump(state, f, indent=4, default=cls._converter)
+            json.dump(state, f, indent=4, default=_job_status_converter)
 
         shutil.move(path, os.path.join(out_path, cls._default_filename))
-
-    def _converter(o):
-        if isinstance(o, JobStatus):
-            return str(o)
-        # pass other types to raise default exception

--- a/chainerui/utils/commands_state.py
+++ b/chainerui/utils/commands_state.py
@@ -6,6 +6,8 @@ import tempfile
 
 from chainer import training
 
+from chainerui.utils.command_item import CommandItem
+
 
 class JobStatus(Enum):
     INITIALIZED = 0
@@ -50,6 +52,13 @@ class CommandsState(object):
     def job_status(cls, out_path):
         state = cls._load(out_path)
         if state is None:
+            if os.path.isfile(CommandItem.commands_path(out_path)):
+                # NOTE: this constraint is for back compatibility <= v0.1.1
+                #       it is possible that set CommandsExtension but
+                #       '.chainerui_commands' is not found. If '.commands'
+                #       is found, judge as 'STOPPED'
+                cls.stop(out_path)
+                return cls.job_status(out_path)
             return JobStatus.NO_EXTENSION_ERROR
         return state['job_status']
 

--- a/chainerui/views/result_command.py
+++ b/chainerui/views/result_command.py
@@ -26,7 +26,11 @@ class ResultCommandAPI(MethodView):
 
         job_status = CommandsState.job_status(result.path_name)
         if job_status != JobStatus.RUNNING:
-            if job_status == JobStatus.INITIALIZED:
+            if job_status == JobStatus.NO_EXTENSION_ERROR:
+                return jsonify({
+                    'message': '\'CommandsExtension\' is not set or disabled.'
+                }), 400
+            elif job_status == JobStatus.INITIALIZED:
                 return jsonify({
                     'message': 'The target training job has not run, yet'
                 }), 400

--- a/chainerui/views/result_command.py
+++ b/chainerui/views/result_command.py
@@ -6,6 +6,8 @@ from chainerui import DB_SESSION
 from chainerui.models.result import Result
 from chainerui.tasks import crawl_result
 from chainerui.utils.command_item import CommandItem
+from chainerui.utils.commands_state import CommandsState
+from chainerui.utils.commands_state import JobStatus
 
 
 class ResultCommandAPI(MethodView):
@@ -21,6 +23,21 @@ class ResultCommandAPI(MethodView):
                 'result': None,
                 'message': 'No interface defined for URL.'
             }), 404
+
+        job_status = CommandsState.job_status(result.path_name)
+        if job_status != JobStatus.RUNNING:
+            if job_status == JobStatus.INITIALIZED:
+                return jsonify({
+                    'message': 'The target training job has not run, yet'
+                }), 400
+            elif job_status == JobStatus.STOPPED:
+                return jsonify({
+                    'message': 'The target training job has already stopped'
+                }), 400
+            else:
+                return jsonify({
+                    'message': 'Cannot get the target training job status'
+                }), 400
 
         request_json = request.get_json()
         if request_json is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+enum34>=1.1.6; python_version < '3.4'
 Flask>=0.12.2
 Werkzeug<0.13
 APScheduler>=3.3.1

--- a/tests/extensions_tests/test_commands_extension.py
+++ b/tests/extensions_tests/test_commands_extension.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from chainer.training import Trainer
+from chainer.training.triggers import IntervalTrigger
+
+from chainerui.extensions.commands_extension import _CommandIntervalTrigger
+from chainerui.extensions.commands_extension import CommandsExtension
+from chainerui.utils.commands_state import CommandsState
+from chainerui.utils.commands_state import JobStatus
+
+
+class _MockTrainer(Trainer):
+    def __init__(self, out_path):
+        self.out = out_path
+        self.stop_trigger = IntervalTrigger(100, 'epoch')
+
+
+class TestCommandsExtension(unittest.TestCase):
+
+    def setUp(self):
+        test_dir = tempfile.mkdtemp(prefix='chainerui_test_cmdext')
+        self._dir = test_dir
+
+    def tearDown(self):
+        if os.path.exists(self._dir):
+            shutil.rmtree(self._dir)
+
+    def test_call_no_command(self):
+        out_path = os.path.join(self._dir, 'results')
+        os.makedirs(out_path)
+        commands_path = os.path.join(out_path, 'commands')
+        open(commands_path, 'w').close()
+        assert os.path.isfile(commands_path)
+
+        target = CommandsExtension()
+        trainer = _MockTrainer(out_path)
+        target.initialize(trainer)
+        assert type(trainer.stop_trigger) is _CommandIntervalTrigger
+        assert not os.path.isfile(commands_path)
+        assert CommandsState.job_status(out_path) == JobStatus.RUNNING
+
+        target.finalize()
+        assert CommandsState.job_status(out_path) == JobStatus.STOPPED

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,6 +117,17 @@ def setup_test_project(root_path):
         json.dump(commands, f)
     CommandsState.stop(path)
 
+    # log, args, commands, status(not run)
+    path = os.path.join(root_path, '10005')
+    os.makedirs(path)
+    with open(os.path.join(path, 'log'), 'w') as f:
+        json.dump(log, f)
+    with open(os.path.join(path, 'args'), 'w') as f:
+        json.dump(args, f)
+    with open(os.path.join(path, 'commands'), 'w') as f:
+        json.dump(commands, f)
+    CommandsState._dump(path, CommandsState._load(path, initialize=True))
+
 
 def setup_test_db(project_path, project_name):
     create_db()
@@ -372,7 +383,7 @@ class TestAPI(unittest.TestCase):
             assert isinstance(command['request']['status'], string_types)
             assert 'response' in command
 
-        # jos is not started
+        # not set extension
         resp = self.app.post(
             '/api/v1/projects/1/results/3/commands',
             data=json.dumps(request_jsons[0]),
@@ -380,7 +391,7 @@ class TestAPI(unittest.TestCase):
         data = assert_json_api(resp, 400)
         assert len(data) == 1
         assert isinstance(data['message'], string_types)
-        assert 'not run' in data['message']
+        assert 'not set' in data['message']
 
         # jos has stopped
         resp = self.app.post(
@@ -391,6 +402,16 @@ class TestAPI(unittest.TestCase):
         assert len(data) == 1
         assert isinstance(data['message'], string_types)
         assert 'stopped' in data['message']
+
+        # not set extension
+        resp = self.app.post(
+            '/api/v1/projects/1/results/6/commands',
+            data=json.dumps(request_jsons[0]),
+            content_type='application/json')
+        data = assert_json_api(resp, 400)
+        assert len(data) == 1
+        assert isinstance(data['message'], string_types)
+        assert 'not run' in data['message']
 
         request_jsons = [
             {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -385,13 +385,23 @@ class TestAPI(unittest.TestCase):
 
         # not set extension
         resp = self.app.post(
-            '/api/v1/projects/1/results/3/commands',
+            '/api/v1/projects/1/results/2/commands',
             data=json.dumps(request_jsons[0]),
             content_type='application/json')
         data = assert_json_api(resp, 400)
         assert len(data) == 1
         assert isinstance(data['message'], string_types)
         assert 'not set' in data['message']
+
+        # job run on v0.1.0 so .chainerui_commands is not created
+        resp = self.app.post(
+            '/api/v1/projects/1/results/3/commands',
+            data=json.dumps(request_jsons[0]),
+            content_type='application/json')
+        data = assert_json_api(resp, 400)
+        assert len(data) == 1
+        assert isinstance(data['message'], string_types)
+        assert 'stopped' in data['message']
 
         # jos has stopped
         resp = self.app.post(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,16 +136,21 @@ class TestAPI(unittest.TestCase):
                 'when you run this test'
             )
 
-    def setUp(self):
         test_dir = tempfile.mkdtemp(prefix='chainerui_test_api')
-        self._dir = test_dir
+        cls._dir = test_dir
         project_path = os.path.join(test_dir, 'test_project')
         setup_test_project(project_path)
-        self._project_path = project_path
+        cls._project_path = project_path
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls._dir):
+            shutil.rmtree(cls._dir)
+
+    def setUp(self):
         project_name = 'my-project'
-        setup_test_db(project_path, project_name)
+        setup_test_db(self._project_path, project_name)
         self._project_name = project_name
-        print(project_path)
 
         app = create_app()
         app.testing = True
@@ -155,8 +160,6 @@ class TestAPI(unittest.TestCase):
         # remove test db if exists
         if os.path.exists(DB_FILE_PATH):
             os.remove(DB_FILE_PATH)
-        if os.path.exists(self._dir):
-            shutil.rmtree(self._dir)
 
     def assert_test_project(self, project, name=None):
         assert len(project) == 3


### PR DESCRIPTION
depends #59 , refs #7, #45

On this PR, when training job is not run, response returns `400` code and not call `CommandsExtension` instance. So error result is not shown for commands history table.