### PR TITLE
fix 404 logic on result API

### DIFF
--- a/chainerui/views/result.py
+++ b/chainerui/views/result.py
@@ -14,12 +14,17 @@ class ResultAPI(MethodView):
 
     def get(self, id=None, project_id=None):
         """get."""
+        project = DB_SESSION.query(Project).\
+            filter_by(id=project_id).\
+            first()
+        if project is None:
+            return jsonify({
+                'project': None,
+                'message': 'No interface defined for URL.'
+            }), 404
 
         if id is None:
 
-            project = DB_SESSION.query(Project).\
-                filter_by(id=project_id).\
-                first()
             collect_results(project)
 
             results = DB_SESSION.query(Result).\
@@ -41,13 +46,13 @@ class ResultAPI(MethodView):
                 filter_by(is_unregistered=False).\
                 first()
 
-            result = crawl_result(result.id)
-
             if result is None:
                 return jsonify({
                     'result': None,
                     'message': 'No interface defined for URL.'
                 }), 404
+
+            result = crawl_result(result.id)
 
             return jsonify({
                 'result': result.serialize

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -230,9 +230,22 @@ class TestAPI(unittest.TestCase):
             self.assert_test_project_result(data['result'])
             assert data['result']['id'] == i + 1
 
-        # raise an unexpected exception
-        #   when GET /api/v1/projects/1/results/12345
-        # not raise an exception when GET /api/v1/projects/12345/results/1
+        # invalid project ID
+        resp = self.app.get('/api/v1/projects/12345/results/1')
+        json_str = resp.data.decode()
+        print('aaa')
+        print(json_str)
+        data = assert_json_api(resp, 404)
+        assert len(data) == 2
+        assert isinstance(data['message'], string_types)
+        assert data['project'] is None
+
+        # invalid result ID
+        resp = self.app.get('/api/v1/projects/1/results/12345')
+        data = assert_json_api(resp, 404)
+        assert len(data) == 2
+        assert isinstance(data['message'], string_types)
+        assert data['result'] is None
 
     # PUT /api/v1/projects/<int:project_id>/results/<int:id>
     def test_put_result(self):


### PR DESCRIPTION
fixes #30 

when project is not found, return 404 on `projects/{id}/result/**` API