### PR TITLE
Feature/show nested value in experiments table

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -72,7 +72,7 @@ export const argValue2string = (argValue) => {
   if (argValue == null) {
     return emptyStr;
   }
-  return (typeof argValue === 'boolean') ? String(argValue) : JSON.stringify(argValue);
+  return (typeof argValue === 'object') ? JSON.stringify(argValue) : String(argValue);
 };
 
 export const isJsonString = (str) => {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -72,7 +72,7 @@ export const argValue2string = (argValue) => {
   if (argValue == null) {
     return emptyStr;
   }
-  return (typeof argValue === 'boolean') ? String(argValue) : argValue;
+  return (typeof argValue === 'boolean') ? String(argValue) : JSON.stringify(argValue);
 };
 
 export const isJsonString = (str) => {


### PR DESCRIPTION
When inputting the following args file, chainerui can't build /project/{project_id} view.
Because, The experiments table can't display nested argValue.

``` args.json
{
    "resume": "", 
    "batchsize": 100, 
    "epoch": 10, 
    "frequency": -1, 
    "gpu": 0, 
    "unit": 1000, 
    "out": "results",
    "test": {
        "aaaa": 111
    }
}
```

In this p-r, experiments table will support nested argValue.