### PR TITLE
Add `episode` and `step` to summary pane

### DIFF
--- a/frontend/src/components/result/ResultSummary.jsx
+++ b/frontend/src/components/result/ResultSummary.jsx
@@ -7,7 +7,7 @@ import { keyOptions } from '../../constants';
 const ResultSummary = (props) => {
   const { result } = props;
   const lastLogDict = getLastLogDict(result);
-  const logKeys = keyOptions.filter((key) => Object.keys(lastLogDict).indexOf(key) > -1);
+  const logKeys = keyOptions.filter((key) => key in lastLogDict);
   return (
     <div className="card">
       <div className="card-header">Summary</div>

--- a/frontend/src/components/result/ResultSummary.jsx
+++ b/frontend/src/components/result/ResultSummary.jsx
@@ -24,7 +24,7 @@ const ResultSummary = (props) => {
 
           {logKeys.map((key) => (
             <React.Fragment key={`summary-${key}`}>
-              <dt className="col-sm-3">{key.split('_').join(' ')}</dt>
+              <dt className="col-sm-3">{key.replace(/_/g, ' ')}</dt>
               <dd className="col-sm-9">{lastLogDict[key]}</dd>
             </React.Fragment>
           ))}

--- a/frontend/src/components/result/ResultSummary.jsx
+++ b/frontend/src/components/result/ResultSummary.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getLastLogDict } from '../../utils';
+import { keyOptions } from '../../constants';
 
 
 const ResultSummary = (props) => {
   const { result } = props;
   const lastLogDict = getLastLogDict(result);
+  const logKeys = keyOptions.filter((key) => Object.keys(lastLogDict).indexOf(key) > -1);
   return (
     <div className="card">
       <div className="card-header">Summary</div>
@@ -20,14 +22,12 @@ const ResultSummary = (props) => {
           <dt className="col-sm-3">path name</dt>
           <dd className="col-sm-9">{result.pathName}</dd>
 
-          <dt className="col-sm-3">epoch</dt>
-          <dd className="col-sm-9">{lastLogDict.epoch}</dd>
-
-          <dt className="col-sm-3">iteration</dt>
-          <dd className="col-sm-9">{lastLogDict.iteration}</dd>
-
-          <dt className="col-sm-3">elapsed time</dt>
-          <dd className="col-sm-9">{lastLogDict.elapsed_time}</dd>
+          {logKeys.map((key) => (
+            <React.Fragment key={`summary-${key}`}>
+              <dt className="col-sm-3">{key.split('_').join(' ')}</dt>
+              <dd className="col-sm-9">{lastLogDict[key]}</dd>
+            </React.Fragment>
+          ))}
         </dl>
       </div>
     </div>

--- a/frontend/src/containers/PlotContainer.jsx
+++ b/frontend/src/containers/PlotContainer.jsx
@@ -138,7 +138,7 @@ const mapEntitiesToStats = (entities) => {
   });
   const argKeys = Object.keys(argKeySet);
   const logKeys = Object.keys(logKeySet).sort();
-  const xAxisKeys = keyOptions.filter((key) => logKeys.indexOf(key) > -1);
+  const xAxisKeys = keyOptions.filter((key) => key in logKeySet);
 
   return { axes, argKeys, logKeys, xAxisKeys };
 };


### PR DESCRIPTION
Fix #66 

I added `episode` and `step` keys to the summary pane like below.
![2018-04-11 18 41 32](https://user-images.githubusercontent.com/4404574/38609164-5756e55a-3db8-11e8-9e0f-c2e049efedd6.png)

This change enables us to add keys easily. We just edit `keyOptions`.
