### PR TITLE
do not crash if logs contain anything else than numbers or strings

### DIFF
--- a/chainerui/models/log.py
+++ b/chainerui/models/log.py
@@ -2,6 +2,7 @@ from math import isinf
 from math import isnan
 
 import msgpack
+import numbers
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
@@ -33,10 +34,18 @@ class Log(DB_BASE):
 
         data = msgpack.unpackb(self.data, encoding='utf-8')
         for item in data.items():
+            value_to_store = (
+                None
+                if not isinstance(item[1], numbers.Number)
+                or isinf(item[1])
+                or isnan(item[1])
+                else item[1]
+            )
+
             log_items.append({
                 'logId': self.id,
                 'key': item[0],
-                'value': None if isinf(item[1]) or isnan(item[1]) else item[1]
+                'value': value_to_store
             })
 
         return {

--- a/tests/model_tests/test_log.py
+++ b/tests/model_tests/test_log.py
@@ -1,0 +1,75 @@
+from chainerui.models.log import Log
+
+
+def get_test_json():
+    return [
+        {
+            "loss": 100,
+            "epoch": 1,
+        },
+        {
+            "loss": 90,
+            "epoch": 2,
+        }
+    ]
+
+
+def find_log_item(log_items, key):
+    matching_log_items = [
+        log_item for log_item in log_items if log_item['key'] == key
+    ]
+    return matching_log_items[0]
+
+
+def test_log_serialize_numbers():
+    json_data = get_test_json()
+    logs = [Log(data) for data in json_data]
+    serialized_data = [log.serialize for log in logs]
+
+    assert find_log_item(serialized_data[0]['logItems'], 'epoch')['value'] == 1
+    assert find_log_item(serialized_data[1]['logItems'], 'epoch')['value'] == 2
+
+
+def test_log_serialize_arbitrary_data():
+    json_data = get_test_json()
+    json_data.insert(
+        0,
+        {
+            "loss": 110,
+            "epoch": 0,
+            "model_files": ["Model", "model.py"]
+        }
+    )
+
+    logs = [Log(data) for data in json_data]
+    serialized_data = [log.serialize for log in logs]
+
+    assert find_log_item(serialized_data[0]['logItems'], 'epoch')['value'] == 0
+    assert find_log_item(
+        serialized_data[0]['logItems'], 'model_files')['value'] is None
+    assert find_log_item(serialized_data[1]['logItems'], 'epoch')['value'] == 1
+    assert find_log_item(serialized_data[2]['logItems'], 'epoch')['value'] == 2
+
+
+def test_log_serialize_nan_and_inf():
+    json_data = get_test_json()
+    json_data.insert(
+        0,
+        {
+            "loss": float('nan'),
+            "epoch": float('inf'),
+            "iteration": 0,
+        }
+    )
+
+    logs = [Log(data) for data in json_data]
+    serialized_data = [log.serialize for log in logs]
+
+    assert find_log_item(
+        serialized_data[0]['logItems'], 'iteration')['value'] == 0
+    assert find_log_item(
+        serialized_data[0]['logItems'], 'epoch')['value'] is None
+    assert find_log_item(
+        serialized_data[0]['logItems'], 'loss')['value'] is None
+    assert find_log_item(serialized_data[1]['logItems'], 'epoch')['value'] == 1
+    assert find_log_item(serialized_data[2]['logItems'], 'epoch')['value'] == 2


### PR DESCRIPTION
The current version of the code does not work in case the log file contains anything else than numbers (`integers` or `floats`). It might happen that some users store values like `lists` in their log.

This PR adds a check that filters all values that are not a number, hence allowing such values in the log file.