### PR TITLE
Resolve circular reference

### DIFF
--- a/chainerui/models/project.py
+++ b/chainerui/models/project.py
@@ -8,7 +8,7 @@ from sqlalchemy import String
 
 from chainerui import DB_BASE
 from chainerui import DB_SESSION
-from chainerui.tasks import collect_results
+from chainerui.tasks.collect_results import collect_results
 
 
 class Project(DB_BASE):

--- a/chainerui/models/result.py
+++ b/chainerui/models/result.py
@@ -10,7 +10,7 @@ from sqlalchemy import String
 
 from chainerui import DB_BASE
 from chainerui import DB_SESSION
-from chainerui.tasks import crawl_result
+from chainerui.tasks.crawl_result import crawl_result
 
 
 class Result(DB_BASE):

--- a/chainerui/models/result.py
+++ b/chainerui/models/result.py
@@ -10,6 +10,7 @@ from sqlalchemy import String
 
 from chainerui import DB_BASE
 from chainerui import DB_SESSION
+from chainerui.tasks import crawl_result
 
 
 class Result(DB_BASE):
@@ -53,10 +54,7 @@ class Result(DB_BASE):
         DB_SESSION.add(result)
         DB_SESSION.commit()
 
-        # TODO(gky360): Fix import issue.
-        # See https://github.com/chainer/chainerui/pull/92 for details
-        from chainerui.tasks import crawl_result
-        crawl_result(result.id, True)
+        crawl_result(result, True)
 
         return result
 

--- a/chainerui/tasks/collect_results.py
+++ b/chainerui/tasks/collect_results.py
@@ -2,6 +2,7 @@ import datetime
 import os
 
 from chainerui import DB_SESSION
+from chainerui.models.result import Result
 
 
 def _list_result_paths(target_path, log_file_name='log'):
@@ -18,9 +19,6 @@ def _list_result_paths(target_path, log_file_name='log'):
 
 
 def _register_result(project_id, result_path):
-    from chainerui import DB_SESSION
-    from chainerui.models.result import Result
-
     result_path = os.path.abspath(result_path)
 
     contain_log_file = os.path.isfile(os.path.join(result_path, 'log'))

--- a/chainerui/tasks/crawl_result.py
+++ b/chainerui/tasks/crawl_result.py
@@ -5,7 +5,6 @@ import os
 from chainerui import DB_SESSION
 from chainerui.models.argument import Argument
 from chainerui.models.log import Log
-from chainerui.models.result import Result
 from chainerui.models.snapshot import Snapshot
 from chainerui.utils.command_item import CommandItem
 from chainerui.utils import is_numberable
@@ -63,11 +62,8 @@ def _check_log_updated(result):
     return False
 
 
-def crawl_result(result_id, force=False):
+def crawl_result(current_result, force=False):
     """crawl_results."""
-
-    current_result = DB_SESSION.query(Result).filter_by(id=result_id).first()
-
     now = datetime.datetime.now()
 
     if (not force) and (now - current_result.updated_at).total_seconds() < 4:

--- a/chainerui/tasks/crawl_result.py
+++ b/chainerui/tasks/crawl_result.py
@@ -62,43 +62,43 @@ def _check_log_updated(result):
     return False
 
 
-def crawl_result(current_result, force=False):
+def crawl_result(result, force=False):
     """crawl_results."""
     now = datetime.datetime.now()
 
-    if (not force) and (now - current_result.updated_at).total_seconds() < 4:
-        return current_result
+    if (not force) and (now - result.updated_at).total_seconds() < 4:
+        return result
 
     # if log file is not updated, not necessary to get log contents
-    is_updated = _check_log_updated(current_result)
-    crawled_result = crawl_result_path(current_result.path_name, is_updated)
+    is_updated = _check_log_updated(result)
+    crawled_result = crawl_result_path(result.path_name, is_updated)
 
     if is_updated:
-        current_log_idx = len(current_result.logs)
+        current_log_idx = len(result.logs)
         if len(crawled_result['logs']) < current_log_idx:
             current_log_idx = 0
-            current_result.logs = []
-            current_result.args = None
+            result.logs = []
+            result.args = None
         for log in crawled_result['logs'][current_log_idx:]:
-            current_result.logs.append(Log(log))
+            result.logs.append(Log(log))
 
-    if current_result.args is None:
-        current_result.args = Argument(json.dumps(crawled_result['args']))
+    if result.args is None:
+        result.args = Argument(json.dumps(crawled_result['args']))
 
-    current_result.commands = []
-    current_result.snapshots = []
+    result.commands = []
+    result.snapshots = []
 
     for cmd in crawled_result['commands']:
-        current_result.commands.append(cmd.to_model())
+        result.commands.append(cmd.to_model())
 
     for snapshot in crawled_result['snapshots']:
         number_str = snapshot.split('snapshot_iter_')[1]
         if is_numberable(number_str):
-            current_result.snapshots.append(
+            result.snapshots.append(
                 Snapshot(snapshot, int(number_str))
             )
 
-    current_result.updated_at = datetime.datetime.now()
+    result.updated_at = datetime.datetime.now()
     DB_SESSION.commit()
 
-    return current_result
+    return result

--- a/chainerui/tasks/crawl_result.py
+++ b/chainerui/tasks/crawl_result.py
@@ -4,9 +4,9 @@ import os
 
 from chainerui import DB_SESSION
 from chainerui.models.argument import Argument
+from chainerui.models.command import Command
 from chainerui.models.log import Log
 from chainerui.models.snapshot import Snapshot
-from chainerui.utils.command_item import CommandItem
 from chainerui.utils import is_numberable
 
 
@@ -35,7 +35,7 @@ def crawl_result_path(result_path, include_log):
         if include_log:
             result['logs'] = load_result_json(result_path, 'log')
         result['args'] = load_result_json(result_path, 'args')
-        result['commands'] = CommandItem.load_commands(result_path)
+        result['commands'] = load_result_json(result_path, 'commands')
 
         snapshots = [
             x for x in os.listdir(result_path) if x.count('snapshot_iter_')
@@ -89,7 +89,7 @@ def crawl_result(result, force=False):
     result.snapshots = []
 
     for cmd in crawled_result['commands']:
-        result.commands.append(cmd.to_model())
+        result.commands.append(Command(**cmd))
 
     for snapshot in crawled_result['snapshots']:
         number_str = snapshot.split('snapshot_iter_')[1]

--- a/chainerui/views/result.py
+++ b/chainerui/views/result.py
@@ -35,7 +35,7 @@ class ResultAPI(MethodView):
                 all()
 
             for result in results:
-                result = crawl_result(result.id)
+                result = crawl_result(result)
 
             return jsonify({
                 'results': [
@@ -56,7 +56,7 @@ class ResultAPI(MethodView):
                     'message': 'No interface defined for URL.'
                 }), 404
 
-            result = crawl_result(result.id)
+            result = crawl_result(result)
 
             return jsonify({
                 'result': result.serialize_with_sampled_logs(logs_limit)

--- a/chainerui/views/result_command.py
+++ b/chainerui/views/result_command.py
@@ -76,7 +76,7 @@ class ResultCommandAPI(MethodView):
 
         CommandItem.dump_commands(commands, result.path_name)
 
-        new_result = crawl_result(result.id, force=True)
+        new_result = crawl_result(result, force=True)
         new_result_dict = new_result.serialize
 
         return jsonify({'commands': new_result_dict['commands']})


### PR DESCRIPTION
- remove to load `Result` model on `crawl_results`
- remove to load `CommandItem` on `crawl_results`
- stop to use preloaded import path
  - `from chainerui.tasks import collect_results` -> `from chainerui.tasks.collect_result import collect_results`

fixes #108 