### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,23 @@
-chainerui/static/dist
-chainerui/chainerui.db
-examples/result
-examples/**/commands
+# python
 *.pyc
-build
+**/__pycache__
 *.egg-info
 *.egg
-.idea/
-.cache/
+build/
 dist/
+.cache/
+.pytest_cache/
 .coverage
 htmlcov/
+
+# frontend
+chainerui/static/dist
+
+# working directory
+examples/result
+examples/mlp.model
+examples/mlp.state
+
+# IDE
+.idea/
+.vscode/


### PR DESCRIPTION
remove `examples/**/commands/` because `commands` file has already committed to https://github.com/chainer/chainerui/tree/master/examples/example_results/19208