### PR TITLE
Stop str() for elements in args

### DIFF
--- a/chainerui/utils/save_args.py
+++ b/chainerui/utils/save_args.py
@@ -30,7 +30,7 @@ def save_args(conditions, out_path):
     with tempdir(prefix='args', dir=out_path) as tempd:
         path = os.path.join(tempd, 'args.json')
         with open(path, 'w') as f:
-            json.dump(args_dict, f, indent=4)
+            json.dump(args, f, indent=4)
 
         new_path = os.path.join(out_path, 'args')
         shutil.move(path, new_path)

--- a/chainerui/utils/save_args.py
+++ b/chainerui/utils/save_args.py
@@ -21,7 +21,6 @@ def save_args(conditions, out_path):
         args = vars(conditions)
     else:
         args = conditions
-    args_dict = {k: str(v) for k, v in args.items()}
 
     try:
         os.makedirs(out_path)

--- a/tests/utils_tests/test_save_args.py
+++ b/tests/utils_tests/test_save_args.py
@@ -30,12 +30,13 @@ class TestSaveArgs(unittest.TestCase):
 
         with open(args_path) as f:
             target = json.load(f)
+
         assert len(target) == 5
-        assert target['int'] == str(1)
-        assert target['float'] == str(0.1)
+        assert target['int'] == 1
+        assert target['float'] == 0.1
         assert target['str'] == 'foo'
-        assert target['inner'] == "{'int': 1}"
-        assert target['array'] == "['boo']"
+        assert target['inner'] == {'int': 1}
+        assert target['array'] == ['boo']
 
     def _create_parser(self):
         parser = argparse.ArgumentParser()
@@ -57,6 +58,6 @@ class TestSaveArgs(unittest.TestCase):
         with open(args_path) as f:
             target = json.load(f)
         assert len(target) == 3
-        assert target['i'] == str(-1)
+        assert target['i'] == -1
         assert target['s'] == 'foo'
-        assert target['a'] == "[0, 100]"
+        assert target['a'] == [0, 100]


### PR DESCRIPTION
This PR may contains needs to be discussed.

## background

I want to use `save_args` for constructing a model in inference.
`args` often contains a lot of model parameters.

In my situation, I have a list object for model parameters like below

```python
class BiLSTM_CRF(chainer.Chain):

    def __init__(self, n_elems, dims, n_label, hidden_dim):
        super(BiLSTM_CRF, self).__init__()
        feature_dim = sum(dims)
        print(feature_dim)
```

And I add `n_elems` and `dims` into args and call `save_args`.

## my problem

`save_args` convert each value in args to `string`.
So I got dict object like below.

```json
{
    "n_elems": "[2073, 18]",
    "dims": "[50, 50]",
    "n_label": "17",
    "hidden_dim": "50"
}
```

We can see `n_elems` and `dims' are the string, which contains the list of integer.
I want `n_elems` and `dims` to be list of integer directly.

```json
{
  "n_elems": [
    [2073, 18]
  ],
  "dims": [
    [50, 50]
  ],
  "n_label": 17,
  "hidden_dim": 50
}
```

Of course, this change may affect frontend application, so I want some discussion about this PR.
And there is the workaround, which is using `json.dump` directly.
But if I can, I want to unify the using API in chainer or chainerUI

Thanks!