### PR TITLE
Add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    python3-dev \
+    python3-pip \
+    python3-wheel \
+    python3-setuptools && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+RUN pip3 install chainerui
+RUN chainerui db create && chainerui db upgrade
+
+EXPOSE 5000
+RUN mkdir /projects
+VOLUME ["/projects"]
+CMD ["chainerui", "server", "--host", "0.0.0.0"]


### PR DESCRIPTION
This Dockerfile use the latest chainerui module uploaded on PyPI. After merged and released next v0.4.0, we will push the image to Duckerhub, chainer/chainerui repository.

I'm going to write the document about quick usage later.