### PR TITLE
Swap a left column for a right column

### DIFF
--- a/frontend/src/containers/PlotContainer.jsx
+++ b/frontend/src/containers/PlotContainer.jsx
@@ -79,7 +79,7 @@ class PlotContainer extends React.Component {
         />
         <Container fluid>
           <div className="row">
-            <div className="col-md-4 col-lg-3">
+            <div className="col-md-4 col-lg-3 order-12 order-md-1">
               <BreadcrumbLink
                 length={2}
                 globalConfig={globalConfig}
@@ -100,7 +100,7 @@ class PlotContainer extends React.Component {
                 onAxisConfigLogKeySelectToggle={this.props.toggleLogKeySelect}
               />
             </div>
-            <div className="col-md-8 col-lg-9">
+            <div className="col-md-8 col-lg-9 order-1 order-md-12">
               <LogVisualizer
                 project={project}
                 results={results}


### PR DESCRIPTION
ChainerUI draws in a single column on narrow screens like smartphones.
At that time, I changed it to display a chart and a table column first.

Before:
<img width="400" alt="2018-08-03 12 08 37" src="https://user-images.githubusercontent.com/280562/43622231-0f9dec88-9716-11e8-8661-a61b4d01919d.png">

After:
<img width="400" alt="2018-08-03 12 08 06" src="https://user-images.githubusercontent.com/280562/43622241-1716987a-9716-11e8-847d-0c58b43b77a3.png">
