### PR TITLE
Fix development server warning

### DIFF
--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -82,7 +82,6 @@ def create_app():
     """create_app."""
 
     app = Flask(__name__)
-    app.config['DEBUG'] = False
     app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
     def dated_url_for(endpoint, **values):

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -1,4 +1,5 @@
 import argparse
+from gevent.pywsgi import WSGIServer
 import os
 
 from chainerui import _version
@@ -9,8 +10,6 @@ from chainerui import DB_SESSION
 from chainerui.models.project import Project
 from chainerui import upgrade_db
 from chainerui.utils import db_revision
-
-from gevent.pywsgi import WSGIServer
 
 
 def _check_db_revision():
@@ -42,7 +41,11 @@ def server_handler(args):
         # - env: production
         # - debug: off
         listener = '{:s}:{:d}'.format(args.host, args.port)
-        http_server = WSGIServer(listener, application=app)
+        http_server = WSGIServer(listener, application=app, log=app.logger)
+        print(' * Environment: production')
+        print(' * Running on http://{}/ (Press CTRL+C to quit)'
+              .format(listener))
+
         http_server.serve_forever()
 
 

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -43,7 +43,7 @@ def server_handler(args):
         # - env: production
         # - debug: off
         listener = '{:s}:{:d}'.format(args.host, args.port)
-        http_server = WSGIServer(listener, application=app, log=app.logger)
+        http_server = WSGIServer(listener, application=app)
 
         def stop_server():
             if http_server.started:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ APScheduler>=3.3.1
 sqlalchemy>=1.1.14
 alembic>=0.9.5
 chainer>=3.0.0
+gevent>=1.2.0


### PR DESCRIPTION
Resolve #107 

Use production server by default.

When we run `chainerui server` , ChainerUI runs with [gevent](http://www.gevent.org/api/gevent.pywsgi.html#module-gevent.pywsgi) production server.
When we run `chainerui server --debug` , ChainerUI runs with flask development server (same behavior as current master branch)

I chose `gevent` from "Self-hosted options" in [Deployment Options](http://flask.pocoo.org/docs/dev/deploying/) .