### PR TITLE
[WIP] Rename /image endpoint to /assets

### DIFF
--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -105,7 +105,7 @@ def create_app():
     @app.route('/')
     @app.route('/projects/<int:project_id>')
     @app.route('/projects/<int:project_id>/results/<int:result_id>')
-    @app.route('/projects/<int:project_id>/results/<int:result_id>/images')
+    @app.route('/projects/<int:project_id>/results/<int:result_id>/assets')
     def index(**kwargs):
         """render react app."""
         return render_template('index.html')
@@ -134,13 +134,13 @@ def create_app():
     from chainerui.views.project import ProjectAPI
     from chainerui.views.result import ResultAPI
     from chainerui.views.result_command import ResultCommandAPI
-    from chainerui.views.result_image import ResultImageAPI
+    from chainerui.views.result_image import ResultAssetAPI
 
     project_resource = ProjectAPI.as_view('project_resource')
     result_resource = ResultAPI.as_view('result_resource')
     result_command_resource = ResultCommandAPI.as_view(
         'result_command_resource')
-    result_image_resource = ResultImageAPI.as_view('result_image_resource')
+    result_assets_resource = ResultAssetAPI.as_view('result_assets_resource')
 
     # project API
     app.add_url_rule(
@@ -167,10 +167,10 @@ def create_app():
 
     # result image API
     app.add_url_rule(
-        '/api/v1/projects/<int:project_id>/results/<int:result_id>/images',
-        view_func=result_image_resource, methods=['GET'])
+        '/api/v1/projects/<int:project_id>/results/<int:result_id>/assets',
+        view_func=result_assets_resource, methods=['GET'])
     app.add_url_rule(
-        '/api/v1/projects/<int:project_id>/results/<int:result_id>/images/<int:content_id>',  # NOQA
-        view_func=result_image_resource, methods=['GET'])
+        '/api/v1/projects/<int:project_id>/results/<int:result_id>/assets/<int:content_id>',  # NOQA
+        view_func=result_assets_resource, methods=['GET'])
 
     return app

--- a/chainerui/views/result_image.py
+++ b/chainerui/views/result_image.py
@@ -12,10 +12,10 @@ from chainerui.models.result import Result
 from chainerui.tasks.collect_images import collect_images
 
 
-class ResultImageAPI(MethodView):
+class ResultAssetAPI(MethodView):
 
     def get(self, result_id=None, project_id=None, content_id=None):
-        # project is not necessary to collect images,
+        # project is not necessary to collect assets,
         # but check parent project exists or not
         project = DB_SESSION.query(Project).\
             filter_by(id=project_id).\
@@ -48,7 +48,7 @@ class ResultImageAPI(MethodView):
                 for content in asset['contents']:
                     content['uri'] = self._make_content_uri(
                         project_id, result_id, content['id'])
-            return jsonify({'images': assets_response})
+            return jsonify({'assets': assets_response})
 
         # sent content binary directly
         bindata = DB_SESSION.query(Bindata).\
@@ -56,7 +56,7 @@ class ResultImageAPI(MethodView):
             first()
         if bindata is None:
             return jsonify({
-                'image': None,
+                'asset': None,
                 'message': 'No interface defined for URL.'
             }), 404
         return send_file(
@@ -66,5 +66,5 @@ class ResultImageAPI(MethodView):
             attachment_filename=bindata.name)
 
     def _make_content_uri(self, project_id, result_id, content_id):
-        return '/api/v1/projects/%d/results/%d/images/%d' % (
+        return '/api/v1/projects/%d/results/%d/assets/%d' % (
             project_id, result_id, content_id)

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -74,9 +74,9 @@ export const RESULT_DELETE_REQUEST = 'RESULT_DELETE_REQUEST';
 export const RESULT_DELETE_SUCCESS = 'RESULT_DELETE_SUCCESS';
 export const RESULT_DELETE_FAILURE = 'RESULT_DELETE_FAILURE';
 export const RESULT_LIST_CLEAR = 'RESULT_LIST_CLEAR';
-export const RESULT_IMAGE_REQUEST = 'RESULT_IMAGE_REQUEST';
-export const RESULT_IMAGE_SUCCESS = 'RESULT_IMAGE_SUCCESS';
-export const RESULT_IMAGE_FAILURE = 'RESULT_IMAGE_FAILURE';
+export const RESULT_ASSET_REQUEST = 'RESULT_ASSET_REQUEST';
+export const RESULT_ASSET_SUCCESS = 'RESULT_ASSET_SUCCESS';
+export const RESULT_ASSET_FAILURE = 'RESULT_ASSET_FAILURE';
 
 export const getResultList = (projectId, logsLimit = -1) => ({
   [CALL_API]: {
@@ -124,10 +124,10 @@ export const clearResultList = () => ({
   type: RESULT_LIST_CLEAR
 });
 
-export const getResultImage = (projectId, resultId) => ({
+export const getResultAsset = (projectId, resultId) => ({
   [CALL_API]: {
-    types: [RESULT_IMAGE_REQUEST, RESULT_IMAGE_SUCCESS, RESULT_IMAGE_FAILURE],
-    endpoint: `projects/${projectId}/results/${resultId}/images`
+    types: [RESULT_ASSET_REQUEST, RESULT_ASSET_SUCCESS, RESULT_ASSET_FAILURE],
+    endpoint: `projects/${projectId}/results/${resultId}/assets`
   }
 });
 

--- a/frontend/src/components/Root.jsx
+++ b/frontend/src/components/Root.jsx
@@ -7,7 +7,7 @@ import configureStore from '../store/configureStore';
 import ProjectsContainer from '../containers/ProjectsContainer';
 import PlotContainer from '../containers/PlotContainer';
 import ResultDetail from '../containers/ResultDetail';
-import ImagesContainer from '../containers/ImagesContainer';
+import AssetsContainer from '../containers/AssetsContainer';
 
 
 const store = configureStore();
@@ -37,7 +37,7 @@ class Root extends React.Component {
           <Route path="/" component={ProjectsContainer} />
           <Route path="/projects/(:projectId)" component={PlotContainer} />
           <Route path="/projects/(:projectId)/results/(:resultId)" component={ResultDetail} />
-          <Route path="/projects/(:projectId)/results/(:resultId)/images" component={ImagesContainer} />
+          <Route path="/projects/(:projectId)/results/(:resultId)/assets" component={AssetsContainer} />
         </Router>
       </Provider>
     );

--- a/frontend/src/components/assets/AssetList.jsx
+++ b/frontend/src/components/assets/AssetList.jsx
@@ -3,10 +3,10 @@ import { Container, Row, Col } from 'reactstrap';
 import PropTypes from 'prop-types';
 
 
-const Images = (props) => {
-  const { images } = props;
+const Assets = (props) => {
+  const { assets } = props;
 
-  const imageCols = (contents) => contents.map((content) => (
+  const assetCols = (contents) => contents.map((content) => (
     <Col>
       <div>{content.tag}</div>
       <div>
@@ -20,12 +20,12 @@ const Images = (props) => {
     return trainInfoValues.map(([k, v]) => (<li>{k}: {v}</li>));
   };
 
-  const srcRowElems = images.map((image) => (
+  const srcRowElems = assets.map((asset) => (
     <Row>
-      {imageCols(image.contents)}
+      {assetCols(asset.contents)}
       <Col>
         <ul>
-          {infoCols(image.train_info)}
+          {infoCols(asset.train_info)}
         </ul>
       </Col>
     </Row>
@@ -38,15 +38,15 @@ const Images = (props) => {
   );
 };
 
-Images.propTypes = {
-  images: PropTypes.arrayOf(PropTypes.shape({
+Assets.propTypes = {
+  assets: PropTypes.arrayOf(PropTypes.shape({
     contents: PropTypes.objectOf(PropTypes.any),
     trainInfo: PropTypes.objectOf(PropTypes.any)
   })).isRequired
 };
 
-Images.defaultProps = {
-  images: []
+Assets.defaultProps = {
+  assets: []
 };
 
-export default Images;
+export default Assets;

--- a/frontend/src/containers/AssetsContainer.jsx
+++ b/frontend/src/containers/AssetsContainer.jsx
@@ -3,24 +3,24 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Container } from 'reactstrap';
 import {
-  getResultImage,
+  getResultAsset,
   updateGlobalPollingRate,
   updateGlobalChartSize
 } from '../actions';
 import NavigationBar from '../components/NavigationBar';
-import Images from '../components/images/ImageList';
+import Assets from '../components/assets/AssetList';
 import { defaultConfig } from '../constants';
 
 
-class ImagesContainer extends React.Component {
+class AssetsContainer extends React.Component {
   componentDidMount() {
     const { projectId, resultId } = this.props;
-    this.props.getResultImage(projectId, resultId);
+    this.props.getResultAsset(projectId, resultId);
   }
 
   render() {
     const {
-      images, globalConfig, fetchState
+      assets, globalConfig, fetchState
     } = this.props;
     return (
       <div>
@@ -31,7 +31,7 @@ class ImagesContainer extends React.Component {
           onGlobalConfigChartSizeUpdate={this.props.updateGlobalChartSize}
         />
         <Container fluid>
-          <Images images={images || []} />
+          <Assets assets={assets || []} />
         </Container>
       </div>
     );
@@ -46,26 +46,26 @@ const mapStateToProps = (state, ownProps) => {
     fetchState,
     config = defaultConfig
   } = state;
-  const { images = [] } = entities;
+  const { assets = [] } = entities;
   const globalConfig = config.global;
-  return { projectId, resultId, images, fetchState, globalConfig };
+  return { projectId, resultId, assets, fetchState, globalConfig };
 };
 
-ImagesContainer.propTypes = {
+AssetsContainer.propTypes = {
   projectId: PropTypes.number.isRequired,
   resultId: PropTypes.number.isRequired,
-  images: PropTypes.objectOf(PropTypes.any).isRequired,
+  assets: PropTypes.objectOf(PropTypes.any).isRequired,
   fetchState: PropTypes.shape({
     resultList: PropTypes.string
   }).isRequired,
   globalConfig: PropTypes.objectOf(PropTypes.any).isRequired,
-  getResultImage: PropTypes.func.isRequired,
+  getResultAsset: PropTypes.func.isRequired,
   updateGlobalPollingRate: PropTypes.func.isRequired,
   updateGlobalChartSize: PropTypes.func.isRequired
 };
 
 export default connect(mapStateToProps, {
-  getResultImage,
+  getResultAsset,
   updateGlobalPollingRate,
   updateGlobalChartSize
-})(ImagesContainer);
+})(AssetsContainer);

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -105,12 +105,12 @@ const resultsReducer = (state = {}, action) => {
 };
 
 
-const imagesReducer = (state = [], action) => {
+const assetsReducer = (state = [], action) => {
   switch (action.type) {
-    case ActionTypes.RESULT_IMAGE_SUCCESS:
-      if (action.response && action.response.images) {
-        const imageList = action.response.images;
-        return imageList;
+    case ActionTypes.RESULT_ASSET_SUCCESS:
+      if (action.response && action.response.assets) {
+        const assetList = action.response.assets;
+        return assetList;
       }
       return state;
     default:
@@ -122,7 +122,7 @@ const imagesReducer = (state = [], action) => {
 const entities = combineReducers({
   projects: projectsReducer,
   results: resultsReducer,
-  images: imagesReducer
+  assets: assetsReducer
 });
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -542,3 +542,67 @@ class TestAPI(unittest.TestCase):
 
         # not raise an exception
         #   when PUT /api/v1/projects/12345/results/4/commands
+
+    # GET /api/v1/projects/<int:project_id>/results/<int:id>/assets
+    def test_get_assets(self):
+        project3_path = os.path.join(self._dir, 'test_project3')
+        path = os.path.join(project3_path, '10004')
+        os.makedirs(path)
+        image_info = [
+            {
+                "epoch": 1,
+                "iteration": 600,
+                "images": {
+                    "train": "iter_600_61b3a8fa.png",
+                    "train_reconstructed": "iter_600_c15c042b.png",
+                }
+            }
+        ]
+        with open(os.path.join(path, '.chainerui_images'), 'w') as f:
+            json.dump(image_info, f)
+        open(os.path.join(path, 'iter_600_61b3a8fa.png'), 'w') .close()
+        open(os.path.join(path, 'iter_600_c15c042b.png'), 'w') .close()
+        with open(os.path.join(path, 'log'), 'w') as f:
+            json.dump([], f)
+        Project.create(project3_path, 'assets-test-project')
+
+        url = '/api/v1/projects/2/results/4/assets'
+        resp = self.app.get(url)
+        data = assert_json_api(resp)
+        assert 'assets' in data
+        assert len(data['assets']) == 1
+        assert 'contents' in data['assets'][0]
+        assert len(data['assets'][0]['contents']) == 2
+        assert 'train_info' in data['assets'][0]
+
+        # invalid project ID
+        resp = self.app.get('/api/v1/projects/12345/results/4/assets')
+        data = assert_json_api(resp, 404)
+        assert len(data) == 2
+        assert isinstance(data['message'], string_types)
+        assert data['project'] is None
+
+        # invalid result ID
+        resp = self.app.get('/api/v1/projects/2/results/12345/assets')
+        data = assert_json_api(resp, 404)
+        assert len(data) == 2
+        assert isinstance(data['message'], string_types)
+        assert data['result'] is None
+
+        # empty assets
+        resp = self.app.get('/api/v1/projects/1/results/1/assets')
+        data = assert_json_api(resp)
+        assert 'assets' in data
+        assert len(data['assets']) == 0
+
+        # resource check
+        resource_url = url + '/1'
+        resp = self.app.get(resource_url)
+        assert resp.status_code == 200
+
+        resource_url = url + '/3'
+        resp = self.app.get(resource_url)
+        data = assert_json_api(resp, 404)
+        assert len(data) == 2
+        assert isinstance(data['message'], string_types)
+        assert data['asset'] is None


### PR DESCRIPTION
**This PR breaks API backward compatibility.**

- change `/images` endpoint to `/assets` 
- in order to support any kind of binary files to show on web browser
- `/images` endpoint is undocumented and experimental but included in v0.3.0~
- this PR changes only endpoint and frontend components
  - I will fix `ImageReporter` extension and related code to support other assets later