### PR TITLE
[WIP] change PyPI deploy condition, not to use tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ deploy:
   user: $PYPI_MAINTAINER_NAME
   password: $PYPI_MAINTAINER_PASS
   on:
-    tags: true
+    condition: '`git describe --abbrev=0 --tags` != v`chainerui -v`'
     python: 3.6
   allow_failure: false
   skip_cleanup: true


### PR DESCRIPTION
From v0.5.0, ChainerUI uploads dist package for PyPI automatically via TravisCI. When maintainer creates a tag, the deploy process will start. This deploy process is not fit with pushing Docker image to Dockerhub, because there is a small lag from upload to `pip install` . When start building docker immediately after making tags, it is possible that "`RUN pip install chainerui`" is not install the latest version.

To resolve it, automatically deploying for PyPI will be started by following condition. The deploying will not conflict making tag and Dockerhub pushing.

* `_version.py` is updated and **not** match with the latest tag

Release tasks are:

1. update `_version.py` and merge to master branch, then PyPI deploy will start
1. make a tag, then release note will be published and Dockerhub deployg will start