### PR TITLE
add index to reduce log search cost

### DIFF
--- a/chainerui/migration/versions/c29d1b4b67fe_add_result_log_index.py
+++ b/chainerui/migration/versions/c29d1b4b67fe_add_result_log_index.py
@@ -1,0 +1,25 @@
+"""empty message
+
+Revision ID: c29d1b4b67fe
+Revises: 6cd7f193a3de
+Create Date: 2018-08-28 09:54:01.296143
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'c29d1b4b67fe'
+down_revision = '6cd7f193a3de'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('idx_result_project_id', 'result', ['project_id'])
+    op.create_index('idx_log_result_id', 'log', ['result_id'])
+
+
+def downgrade():
+    op.drop_index('idx_log_result_id')
+    op.drop_index('idx_result_project_id')


### PR DESCRIPTION
If a project has many results, searching cost of logs cannot be ignored. This PR reduces the searching cost by indexing.

Benchmark

- test data:1 project, 100 results, each results have 300 log items
- before
  - 0.2~0.3 sec per fetching logs to result object
- after
  - 0.01~0.03 sec