### PR TITLE
Add DB option enable to select other DB

### DIFF
--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -1,8 +1,5 @@
 import os
 
-from alembic.command import downgrade
-from alembic.command import upgrade
-from alembic.config import Config
 from flask import Flask
 from flask import jsonify
 from flask import render_template
@@ -18,27 +15,6 @@ __version__ = _version.__version__
 
 
 CHAINERUI_ENV = os.getenv('CHAINERUI_ENV', 'production')
-PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
-
-
-def get_db_migration_config():
-    ini_path = os.path.join(PACKAGE_DIR, 'alembic.ini')
-    config = Config(ini_path)
-    config.set_main_option(
-        'script_location', os.path.join(PACKAGE_DIR, 'migration'))
-    config.set_main_option('url', db.url)
-    return config
-
-
-def upgrade_db():
-    """upgrade_db."""
-    config = get_db_migration_config()
-    upgrade(config, 'head')
-
-
-def downgrade_db():
-    config = get_db_migration_config()
-    downgrade(config, 'base')
 
 
 def create_app():

--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -1,6 +1,6 @@
-import errno
 import os
 
+from alembic.command import downgrade
 from alembic.command import upgrade
 from alembic.config import Config
 from flask import Flask
@@ -8,74 +8,37 @@ from flask import jsonify
 from flask import render_template
 from flask import send_from_directory
 from flask import url_for
-from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm import sessionmaker
 
 from chainerui import _version
+from chainerui.database import db
 
 
 __version__ = _version.__version__
 
 
 CHAINERUI_ENV = os.getenv('CHAINERUI_ENV', 'production')
-CHAINERUI_ROOT = os.path.abspath(
-    os.path.expanduser(os.getenv('CHAINERUI_ROOT', '~/.chainerui')))
 PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
-DB_FILE_DIR = os.path.join(CHAINERUI_ROOT, 'db')
-DB_FILE_NAME = 'chainerui_test.db' if CHAINERUI_ENV == 'test' \
-    else 'chainerui.db'
-DB_FILE_PATH = os.path.join(DB_FILE_DIR, DB_FILE_NAME)
-SQLALCHEMY_DATABASE_URI = 'sqlite:///' + DB_FILE_PATH
-ENGINE = create_engine(
-    SQLALCHEMY_DATABASE_URI,
-    convert_unicode=True,
-    connect_args={'check_same_thread': False},
-    echo=(CHAINERUI_ENV == 'development')
-)
-DB_BASE = declarative_base()
-DB_SESSION = scoped_session(
-    sessionmaker(autocommit=False, autoflush=False, bind=ENGINE)
-)
 
 
 def get_db_migration_config():
     ini_path = os.path.join(PACKAGE_DIR, 'alembic.ini')
     config = Config(ini_path)
     config.set_main_option(
-        "script_location", os.path.join(PACKAGE_DIR, 'migration'))
+        'script_location', os.path.join(PACKAGE_DIR, 'migration'))
+    config.set_main_option('url', db.url)
     return config
-
-
-def create_db():
-    """create_db."""
-    try:
-        os.makedirs(DB_FILE_DIR)
-    except OSError as exception:
-        if exception.errno == errno.EEXIST and os.path.isdir(DB_FILE_DIR):
-            pass
-        else:
-            raise
-    print('DB_FILE_PATH: ', DB_FILE_PATH)
 
 
 def upgrade_db():
     """upgrade_db."""
-    if not os.path.isdir(DB_FILE_DIR):
-        print('DB is not initialized, please run \'create\' command before')
-        return
     config = get_db_migration_config()
     upgrade(config, 'head')
 
 
-def create_db_session():
-    """create_db_session."""
-    session = scoped_session(
-        sessionmaker(autocommit=False, autoflush=False, bind=ENGINE)
-    )
-    return session()
+def downgrade_db():
+    config = get_db_migration_config()
+    downgrade(config, 'base')
 
 
 def create_app():
@@ -100,7 +63,7 @@ def create_app():
 
     @app.teardown_appcontext
     def shutdown_session(exception=None):
-        DB_SESSION.remove()
+        db.session.remove()
 
     @app.route('/')
     @app.route('/projects/<int:project_id>')

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -9,9 +9,7 @@ from chainerui import _version
 from chainerui import CHAINERUI_ENV
 from chainerui import create_app
 from chainerui import db
-from chainerui import downgrade_db
 from chainerui.models.project import Project
-from chainerui import upgrade_db
 from chainerui.utils import db_revision
 
 
@@ -87,15 +85,15 @@ def db_handler(args):
         print('current_rev', current_rev)
 
     if args.type == 'upgrade':
-        upgrade_db()
+        db.upgrade()
 
     if args.type == 'revision':
         db_revision.new_revision()
 
     if args.type == 'drop':
         if args.db is not None:
-            downgrade_db()
-        db.drop()
+            db.downgrade()
+        db.remove_db()
 
 
 def project_create_handler(args):

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -15,13 +15,10 @@ from chainerui import upgrade_db
 from chainerui.utils import db_revision
 
 
-def _setup_db(url=None):
-    if not db.check(url):
-        return False
+def _setup_db(db_url):
     test_mode = CHAINERUI_ENV == 'test'
     echo = CHAINERUI_ENV == 'development'
-    db.setup(url=url, test_mode=test_mode, echo=echo)
-    return True
+    return db.setup(url=db_url, test_mode=test_mode, echo=echo)
 
 
 def _check_db_revision():
@@ -78,7 +75,8 @@ def db_handler(args):
     """db_handler."""
 
     if args.type == 'create':
-        db.init(args.db)
+        if args.db is None:
+            db.init_db()
         return
 
     if not _setup_db(args.db):
@@ -97,7 +95,7 @@ def db_handler(args):
     if args.type == 'drop':
         if args.db is not None:
             downgrade_db()
-        db.drop(args.db)
+        db.drop()
 
 
 def project_create_handler(args):

--- a/chainerui/database.py
+++ b/chainerui/database.py
@@ -1,0 +1,93 @@
+import errno
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session
+from sqlalchemy.orm import sessionmaker
+
+
+BASE = declarative_base()
+
+
+class Database(object):
+    def __init__(self):
+        self._initialized = False
+        self._engine = None
+        self._session = None
+
+    def init(self, url=None):
+        if url is None:
+            return
+
+        db_dir = self._sqlite_db_dir()
+        try:
+            os.makedirs(db_dir)
+        except OSError as e:
+            if e.errno == errno.EEXIST and os.path.isdir(db_dir):
+                pass
+            else:
+                raise
+        print('DB_FILE_PATH:', db_dir)
+
+    def setup(self, url=None, test_mode=False, echo=False):
+        if url is None:
+            url = self._sqlite_url(test_mode)
+        if url.startswith('sqlite'):
+            connect_args = {'check_same_thread': False}
+        else:
+            connect_args = {}
+        self.url = url
+
+        engine = create_engine(
+            url,
+            convert_unicode=True,
+            connect_args=connect_args,
+            echo=echo
+        )
+        self._engine = engine
+        self._session = scoped_session(
+            sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        )
+        self._initialized = True
+
+    def check(self, url=None):
+        if url is None:
+            if not os.path.isdir(self._sqlite_db_dir()):
+                print('DB is not initialized, please run \'create\' command '
+                      'before')
+                return False
+        return True
+
+    def drop(self, url=None, test_mode=False):
+        if url is None:
+            path = self._sqlite_db_path(test_mode)
+            if os.path.exists(path):
+                os.remove(path)
+
+    def _sqlite_db_dir(self):
+        root = os.path.abspath(
+            os.path.expanduser(os.getenv('CHAINERUI_ROOT', '~/.chainerui')))
+        return os.path.join(root, 'db')
+
+    def _sqlite_db_path(self, test_mode):
+        db_file_name = 'chainerui_test.db' if test_mode else 'chainerui.db'
+        return os.path.join(self._sqlite_db_dir(), db_file_name)
+
+    def _sqlite_url(self, test_mode):
+        return 'sqlite:///' + self._sqlite_db_path(test_mode)
+
+    @property
+    def engine(self):
+        if not self._initialized:
+            raise ValueError('not setup database engine')
+        return self._engine
+
+    @property
+    def session(self):
+        if not self._initialized:
+            raise ValueError('not setup database session')
+        return self._session
+
+
+db = Database()

--- a/chainerui/database.py
+++ b/chainerui/database.py
@@ -17,7 +17,7 @@ class Database(object):
         self._session = None
 
     def init(self, url=None):
-        if url is None:
+        if url is not None:
             return
 
         db_dir = self._sqlite_db_dir()

--- a/chainerui/database.py
+++ b/chainerui/database.py
@@ -18,11 +18,10 @@ class Database(object):
         self._engine = None
         self._session = None
         self._external_db = False
+        self._sqlite_db_file_path = None
 
-    def init_db(self, db_dir=None):
-        if db_dir is None:
-            db_dir = self._sqlite_default_db_dir()
-        self._sqlite_db_dir = db_dir
+    def init_db(self):
+        db_dir = self._sqlite_default_db_dir()
         try:
             os.makedirs(db_dir)
         except OSError as e:
@@ -34,8 +33,9 @@ class Database(object):
 
     def setup(self, url=None, test_mode=False, echo=False):
         if url is None:
+            db_dir = self._sqlite_default_db_dir()
             db_file_name = 'chainerui_test.db' if test_mode else 'chainerui.db'
-            db_path = os.path.join(self._sqlite_db_dir, db_file_name)
+            db_path = os.path.join(db_dir, db_file_name)
             self._sqlite_db_file_path = db_path
             url = 'sqlite:///' + db_path
         else:
@@ -66,7 +66,7 @@ class Database(object):
 
     def _check(self):
         if not self._external_db:
-            if not os.path.isdir(self._sqlite_db_dir):
+            if not os.path.isdir(self._sqlite_default_db_dir()):
                 print('DB is not initialized, please run \'create\' command '
                       'before')
                 return False
@@ -74,7 +74,7 @@ class Database(object):
         return True
 
     def drop(self):
-        if not self._external_db:
+        if not self._external_db and self._sqlite_db_file_path is not None:
             if os.path.exists(self._sqlite_db_file_path):
                 os.remove(self._sqlite_db_file_path)
         self.__init__()  # initialize all attribute

--- a/chainerui/migration/env.py
+++ b/chainerui/migration/env.py
@@ -1,8 +1,7 @@
 import alembic
+from alembic import context
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
-
-from chainerui import SQLALCHEMY_DATABASE_URI
 
 
 def run_migrations_online(config):
@@ -26,8 +25,8 @@ def run_migrations_online(config):
 
 def main():
     """main."""
-    config = alembic.config.Config()
-    config.set_main_option("sqlalchemy.url", SQLALCHEMY_DATABASE_URI)
+    config = context.config
+    config.set_main_option("sqlalchemy.url", config.get_main_option('url'))
     run_migrations_online(config)
 
 

--- a/chainerui/migration/versions/4e779a5fc57e_add_is_unregistered_to_result.py
+++ b/chainerui/migration/versions/4e779a5fc57e_add_is_unregistered_to_result.py
@@ -23,5 +23,5 @@ def upgrade():
 
 
 def downgrade():
-    with op.batch_alter_table('command') as batch_op:
+    with op.batch_alter_table('result') as batch_op:
         batch_op.drop_column('is_unregistered')

--- a/chainerui/models/argument.py
+++ b/chainerui/models/argument.py
@@ -5,10 +5,10 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 
-from chainerui import DB_BASE
+from chainerui import database
 
 
-class Argument(DB_BASE):
+class Argument(database.BASE):
     """Argument Model."""
     __tablename__ = 'argument'
 

--- a/chainerui/models/asset.py
+++ b/chainerui/models/asset.py
@@ -8,11 +8,11 @@ from sqlalchemy import Integer
 from sqlalchemy.orm import relationship
 from sqlalchemy import String
 
-from chainerui import DB_BASE
-from chainerui import DB_SESSION
+from chainerui import database
+from chainerui import db
 
 
-class Asset(DB_BASE):
+class Asset(database.BASE):
     __tablename__ = 'asset'
 
     id = Column(Integer, primary_key=True)
@@ -32,8 +32,8 @@ class Asset(DB_BASE):
         """Initialize an instance and save it to db."""
         asset = cls(result_id, summary, file_modified_at)
 
-        DB_SESSION.add(asset)
-        DB_SESSION.commit()
+        db.session.add(asset)
+        db.session.commit()
 
         return asset
 

--- a/chainerui/models/bindata.py
+++ b/chainerui/models/bindata.py
@@ -4,10 +4,10 @@ from sqlalchemy import Integer
 from sqlalchemy import LargeBinary
 from sqlalchemy import String
 
-from chainerui import DB_BASE
+from chainerui import database
 
 
-class Bindata(DB_BASE):
+class Bindata(database.BASE):
     __tablename__ = 'bindata'
 
     id = Column(Integer, primary_key=True)

--- a/chainerui/models/command.py
+++ b/chainerui/models/command.py
@@ -5,10 +5,10 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 
-from chainerui import DB_BASE
+from chainerui import database
 
 
-class Command(DB_BASE):
+class Command(database.BASE):
     """Command Model."""
     __tablename__ = 'command'
 

--- a/chainerui/models/log.py
+++ b/chainerui/models/log.py
@@ -8,10 +8,10 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import LargeBinary
 
-from chainerui import DB_BASE
+from chainerui import database
 
 
-class Log(DB_BASE):
+class Log(database.BASE):
     """Log Model."""
     __tablename__ = 'log'
 

--- a/chainerui/models/project.py
+++ b/chainerui/models/project.py
@@ -6,12 +6,12 @@ from sqlalchemy import Integer
 from sqlalchemy.orm import relationship
 from sqlalchemy import String
 
-from chainerui import DB_BASE
-from chainerui import DB_SESSION
+from chainerui import database
+from chainerui import db
 from chainerui.tasks.collect_results import collect_results
 
 
-class Project(DB_BASE):
+class Project(database.BASE):
     """Project Model."""
     __tablename__ = 'project'
 
@@ -38,8 +38,8 @@ class Project(DB_BASE):
 
         project = cls(path_name, name)
 
-        DB_SESSION.add(project)
-        DB_SESSION.commit()
+        db.session.add(project)
+        db.session.commit()
 
         collect_results(project, force=True)
         return project

--- a/chainerui/models/result.py
+++ b/chainerui/models/result.py
@@ -8,12 +8,12 @@ from sqlalchemy import Integer
 from sqlalchemy.orm import relationship
 from sqlalchemy import String
 
-from chainerui import DB_BASE
-from chainerui import DB_SESSION
+from chainerui import database
+from chainerui import db
 from chainerui.tasks.crawl_result import crawl_result
 
 
-class Result(DB_BASE):
+class Result(database.BASE):
     """Result Model."""
     __tablename__ = 'result'
 
@@ -51,8 +51,8 @@ class Result(DB_BASE):
         """Initialize an instance and save it to db."""
         result = cls(path_name, name, project_id, log_modified_at)
 
-        DB_SESSION.add(result)
-        DB_SESSION.commit()
+        db.session.add(result)
+        db.session.commit()
 
         crawl_result(result, True)
 

--- a/chainerui/models/snapshot.py
+++ b/chainerui/models/snapshot.py
@@ -3,10 +3,10 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 
-from chainerui import DB_BASE
+from chainerui import database
 
 
-class Snapshot(DB_BASE):
+class Snapshot(database.BASE):
     """Snapshot Model."""
     __tablename__ = 'snapshot'
 

--- a/chainerui/tasks/collect_images.py
+++ b/chainerui/tasks/collect_images.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import os
 
-from chainerui import DB_SESSION
+from chainerui import db
 from chainerui.models.asset import Asset
 from chainerui.models.bindata import Bindata
 
@@ -45,6 +45,6 @@ def collect_images(result, assets, force=False):
             asset.content_list.append(content)
         assets.append(asset)
 
-    DB_SESSION.commit()
+    db.session.commit()
 
     return assets

--- a/chainerui/tasks/collect_results.py
+++ b/chainerui/tasks/collect_results.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 
-from chainerui import DB_SESSION
+from chainerui import db
 from chainerui.models.result import Result
 
 
@@ -26,7 +26,7 @@ def _register_result(project_id, result_path):
     if not contain_log_file:
         return False
 
-    result_size = DB_SESSION.query(Result).filter_by(
+    result_size = db.session.query(Result).filter_by(
         path_name=result_path
     ).count()
 
@@ -52,4 +52,4 @@ def collect_results(project, force=False):
 
     project.updated_at = datetime.datetime.now()
 
-    DB_SESSION.commit()
+    db.session.commit()

--- a/chainerui/tasks/crawl_result.py
+++ b/chainerui/tasks/crawl_result.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import os
 
-from chainerui import DB_SESSION
+from chainerui import db
 from chainerui.models.argument import Argument
 from chainerui.models.command import Command
 from chainerui.models.log import Log
@@ -102,6 +102,6 @@ def crawl_result(result, force=False):
             )
 
     result.updated_at = datetime.datetime.now()
-    DB_SESSION.commit()
+    db.session.commit()
 
     return result

--- a/chainerui/utils/db_revision.py
+++ b/chainerui/utils/db_revision.py
@@ -2,12 +2,12 @@ from alembic.command import revision
 from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
 
-from chainerui import ENGINE
+from chainerui import db
 from chainerui import get_db_migration_config
 
 
 def current_db_revision():
-    ctx = MigrationContext.configure(ENGINE.connect())
+    ctx = MigrationContext.configure(db.engine.connect())
     return ctx.get_current_revision()
 
 

--- a/chainerui/utils/db_revision.py
+++ b/chainerui/utils/db_revision.py
@@ -3,7 +3,6 @@ from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
 
 from chainerui import db
-from chainerui import get_db_migration_config
 
 
 def current_db_revision():
@@ -16,7 +15,7 @@ def check_current_db_revision():
     if current_rev is None:
         return False
 
-    config = get_db_migration_config()
+    config = db.alembic_config
     script = ScriptDirectory.from_config(config)
     module_rev = script.get_current_head()
     if current_rev != module_rev:
@@ -26,5 +25,5 @@ def check_current_db_revision():
 
 
 def new_revision():
-    config = get_db_migration_config()
+    config = db.alembic_config
     revision(config)

--- a/chainerui/views/project.py
+++ b/chainerui/views/project.py
@@ -2,7 +2,7 @@ from flask import jsonify
 from flask import request
 from flask.views import MethodView
 
-from chainerui import DB_SESSION
+from chainerui import db
 from chainerui.models.project import Project
 
 
@@ -13,13 +13,13 @@ class ProjectAPI(MethodView):
         """get."""
 
         if id is None:
-            projects = DB_SESSION.query(Project).all()
+            projects = db.session.query(Project).all()
             return jsonify({
                 'projects': [project.serialize for project in projects]
             })
 
         else:
-            project = DB_SESSION.query(Project).filter_by(id=id).first()
+            project = db.session.query(Project).filter_by(id=id).first()
             if project is None:
                 return jsonify({
                     'project': None,
@@ -42,7 +42,7 @@ class ProjectAPI(MethodView):
         if name == '':
             name = path
 
-        project = DB_SESSION.query(Project).filter_by(path_name=path).first()
+        project = db.session.query(Project).filter_by(path_name=path).first()
         if project is None:
             project = Project.create(path, name)
             return jsonify({
@@ -57,7 +57,7 @@ class ProjectAPI(MethodView):
     def put(self, id):
         """put."""
 
-        project = DB_SESSION.query(Project).filter_by(id=id).first()
+        project = db.session.query(Project).filter_by(id=id).first()
 
         if project is None:
             return jsonify({
@@ -71,8 +71,8 @@ class ProjectAPI(MethodView):
         if project_name is not None:
             project.name = project_name
 
-        DB_SESSION.add(project)
-        DB_SESSION.commit()
+        db.session.add(project)
+        db.session.commit()
 
         return jsonify({
             'project': project.serialize
@@ -80,7 +80,7 @@ class ProjectAPI(MethodView):
 
     def delete(self, id):
         """delete."""
-        project = DB_SESSION.query(Project).filter_by(id=id).first()
+        project = db.session.query(Project).filter_by(id=id).first()
 
         if project is None:
             response = jsonify({
@@ -89,8 +89,8 @@ class ProjectAPI(MethodView):
             })
             return response, 404
 
-        DB_SESSION.delete(project)
-        DB_SESSION.commit()
+        db.session.delete(project)
+        db.session.commit()
 
         return jsonify({
             'project': project.serialize

--- a/chainerui/views/result.py
+++ b/chainerui/views/result.py
@@ -2,7 +2,7 @@ from flask import jsonify
 from flask import request
 from flask.views import MethodView
 
-from chainerui import DB_SESSION
+from chainerui import db
 from chainerui.models.project import Project
 from chainerui.models.result import Result
 from chainerui.tasks import collect_results
@@ -16,7 +16,7 @@ class ResultAPI(MethodView):
         """get."""
         logs_limit = request.args.get('logs_limit', default=-1, type=int)
 
-        project = DB_SESSION.query(Project).\
+        project = db.session.query(Project).\
             filter_by(id=project_id).\
             first()
         if project is None:
@@ -29,7 +29,7 @@ class ResultAPI(MethodView):
 
             collect_results(project)
 
-            results = DB_SESSION.query(Result).\
+            results = db.session.query(Result).\
                 filter_by(project_id=project_id).\
                 filter_by(is_unregistered=False).\
                 all()
@@ -45,7 +45,7 @@ class ResultAPI(MethodView):
 
         else:
 
-            result = DB_SESSION.query(Result).\
+            result = db.session.query(Result).\
                 filter_by(id=id).\
                 filter_by(is_unregistered=False).\
                 first()
@@ -64,7 +64,7 @@ class ResultAPI(MethodView):
 
     def put(self, id, project_id=None):
         """put."""
-        result = DB_SESSION.query(Result).filter_by(id=id).first()
+        result = db.session.query(Result).filter_by(id=id).first()
         if result is None:
             response = jsonify({
                 'result': None, 'message': 'No interface defined for URL.'
@@ -82,21 +82,21 @@ class ResultAPI(MethodView):
         if is_unregistered is not None:
             result.is_unregistered = is_unregistered
 
-        DB_SESSION.add(result)
-        DB_SESSION.commit()
+        db.session.add(result)
+        db.session.commit()
 
         return jsonify({'result': result.serialize})
 
     def delete(self, id, project_id=None):
         """delete."""
-        result = DB_SESSION.query(Result).filter_by(id=id).first()
+        result = db.session.query(Result).filter_by(id=id).first()
         if result is None:
             response = jsonify({
                 'result': None, 'message': 'No interface defined for URL.'
             })
             return response, 404
 
-        DB_SESSION.delete(result)
-        DB_SESSION.commit()
+        db.session.delete(result)
+        db.session.commit()
 
         return jsonify({'result': result.serialize})

--- a/chainerui/views/result_command.py
+++ b/chainerui/views/result_command.py
@@ -2,7 +2,7 @@ from flask import jsonify
 from flask import request
 from flask.views import MethodView
 
-from chainerui import DB_SESSION
+from chainerui import db
 from chainerui.models.result import Result
 from chainerui.tasks import crawl_result
 from chainerui.utils.command_item import CommandItem
@@ -16,7 +16,7 @@ class ResultCommandAPI(MethodView):
     def post(self, result_id, project_id):
         """POST /api/v1/results/<int:id>/commands."""
 
-        result = DB_SESSION.query(Result).filter_by(id=result_id).first()
+        result = db.session.query(Result).filter_by(id=result_id).first()
 
         if result is None:
             return jsonify({

--- a/chainerui/views/result_image.py
+++ b/chainerui/views/result_image.py
@@ -4,7 +4,7 @@ from flask import jsonify
 from flask import send_file
 from flask.views import MethodView
 
-from chainerui import DB_SESSION
+from chainerui import db
 from chainerui.models.asset import Asset
 from chainerui.models.bindata import Bindata
 from chainerui.models.project import Project
@@ -17,7 +17,7 @@ class ResultImageAPI(MethodView):
     def get(self, result_id=None, project_id=None, content_id=None):
         # project is not necessary to collect images,
         # but check parent project exists or not
-        project = DB_SESSION.query(Project).\
+        project = db.session.query(Project).\
             filter_by(id=project_id).\
             first()
         if project is None:
@@ -26,7 +26,7 @@ class ResultImageAPI(MethodView):
                 'message': 'No interface defined for URL.'
             }), 404
 
-        result = DB_SESSION.query(Result).\
+        result = db.session.query(Result).\
             filter_by(id=result_id).\
             filter_by(is_unregistered=False).\
             first()
@@ -37,7 +37,7 @@ class ResultImageAPI(MethodView):
             }), 404
 
         if content_id is None:
-            assets = DB_SESSION.query(Asset).\
+            assets = db.session.query(Asset).\
                 filter_by(result_id=result_id).\
                 order_by(Asset.id).all()
             if assets is None:
@@ -51,7 +51,7 @@ class ResultImageAPI(MethodView):
             return jsonify({'images': assets_response})
 
         # sent content binary directly
-        bindata = DB_SESSION.query(Bindata).\
+        bindata = db.session.query(Bindata).\
             filter_by(id=content_id).\
             first()
         if bindata is None:

--- a/tests/migration_tests/versions_tests/test_alter_log_data_type.py
+++ b/tests/migration_tests/versions_tests/test_alter_log_data_type.py
@@ -24,6 +24,7 @@ class TestUpgrade(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
+        db.init()
         db.setup(test_mode=True)
         cls.db_file_path = db._sqlite_db_path(test_mode=True)
 

--- a/tests/migration_tests/versions_tests/test_alter_log_data_type.py
+++ b/tests/migration_tests/versions_tests/test_alter_log_data_type.py
@@ -1,17 +1,14 @@
 from contextlib import closing
 import json
-import os
 import sqlite3
 import unittest
 
 import alembic
-from alembic.config import Config
 import msgpack
 
 from chainerui import CHAINERUI_ENV
 from chainerui import db
 from chainerui.migration.versions import e3db52a480f8_alter_log_data_type as target  # NOQA
-from chainerui import PACKAGE_DIR
 from tests.helpers import NotInTestEnvironmentException
 
 
@@ -28,11 +25,7 @@ class TestUpgrade(unittest.TestCase):
         db.setup(test_mode=True)
         cls.db_file_path = db._sqlite_db_file_path
 
-        ini_path = os.path.join(PACKAGE_DIR, 'alembic.ini')
-        config = Config(ini_path)
-        config.set_main_option(
-            "script_location", os.path.join(PACKAGE_DIR, 'migration'))
-        config.set_main_option('url', db.url)
+        config = db.alembic_config
         cls._config = config
 
         script_dir = alembic.script.ScriptDirectory.from_config(config)
@@ -44,7 +37,7 @@ class TestUpgrade(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         db.session.remove()
-        db.drop()
+        db.remove_db()
 
     def test_upgrade_downgrade(self):
         # NOTE: don't use alembic operation module, the module is not

--- a/tests/migration_tests/versions_tests/test_alter_log_data_type.py
+++ b/tests/migration_tests/versions_tests/test_alter_log_data_type.py
@@ -24,15 +24,15 @@ class TestUpgrade(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
-        db.init()
+        db.init_db()
         db.setup(test_mode=True)
-        cls.db_file_path = db._sqlite_db_path(test_mode=True)
+        cls.db_file_path = db._sqlite_db_file_path
 
         ini_path = os.path.join(PACKAGE_DIR, 'alembic.ini')
         config = Config(ini_path)
         config.set_main_option(
             "script_location", os.path.join(PACKAGE_DIR, 'migration'))
-        config.set_main_option('url', db._sqlite_url(test_mode=True))
+        config.set_main_option('url', db.url)
         cls._config = config
 
         script_dir = alembic.script.ScriptDirectory.from_config(config)
@@ -44,7 +44,7 @@ class TestUpgrade(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         db.session.remove()
-        db.drop(test_mode=True)
+        db.drop()
 
     def test_upgrade_downgrade(self):
         # NOTE: don't use alembic operation module, the module is not

--- a/tests/migration_tests/versions_tests/test_alter_log_data_type.py
+++ b/tests/migration_tests/versions_tests/test_alter_log_data_type.py
@@ -43,6 +43,7 @@ class TestUpgrade(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        db.session.remove()
         db.drop(test_mode=True)
 
     def test_upgrade_downgrade(self):

--- a/tests/tasks_tests/test_collect_images.py
+++ b/tests/tasks_tests/test_collect_images.py
@@ -6,9 +6,7 @@ import tempfile
 import unittest
 
 from chainerui import CHAINERUI_ENV
-from chainerui import create_db
-from chainerui import DB_FILE_PATH
-from chainerui import DB_SESSION
+from chainerui import db
 from chainerui.models.result import Result
 from chainerui.tasks import collect_images
 from chainerui import upgrade_db
@@ -24,9 +22,9 @@ class TestApp(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
+        db.setup(test_mode=True)
 
     def setUp(self):
-        create_db()
         upgrade_db()
 
         dir = tempfile.mkdtemp(prefix='chainerui_test_collect_images')
@@ -66,9 +64,8 @@ class TestApp(unittest.TestCase):
     def tearDown(self):
         if os.path.exists(self._dir):
             shutil.rmtree(self._dir)
-        DB_SESSION.remove()
-        if os.path.exists(DB_FILE_PATH):
-            os.remove(DB_FILE_PATH)
+        db.session.remove()
+        db.drop(test_mode=True)
 
     def _get_dummy_result(self):
         r = Result(path_name=self._dir)

--- a/tests/tasks_tests/test_collect_images.py
+++ b/tests/tasks_tests/test_collect_images.py
@@ -22,6 +22,7 @@ class TestApp(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
+        db.init()
         db.setup(test_mode=True)
 
     def setUp(self):

--- a/tests/tasks_tests/test_collect_images.py
+++ b/tests/tasks_tests/test_collect_images.py
@@ -9,7 +9,6 @@ from chainerui import CHAINERUI_ENV
 from chainerui import db
 from chainerui.models.result import Result
 from chainerui.tasks import collect_images
-from chainerui import upgrade_db
 from tests.helpers import NotInTestEnvironmentException
 
 
@@ -26,7 +25,7 @@ class TestApp(unittest.TestCase):
 
     def setUp(self):
         db.setup(test_mode=True)
-        upgrade_db()
+        db.upgrade()
 
         dir = tempfile.mkdtemp(prefix='chainerui_test_collect_images')
         info_path = os.path.join(dir, '.chainerui_images')
@@ -66,7 +65,7 @@ class TestApp(unittest.TestCase):
         if os.path.exists(self._dir):
             shutil.rmtree(self._dir)
         db.session.remove()
-        db.drop()
+        db.remove_db()
 
     def _get_dummy_result(self):
         r = Result(path_name=self._dir)

--- a/tests/tasks_tests/test_collect_images.py
+++ b/tests/tasks_tests/test_collect_images.py
@@ -22,7 +22,7 @@ class TestApp(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
-        db.init()
+        db.init_db()
 
     def setUp(self):
         db.setup(test_mode=True)
@@ -66,7 +66,7 @@ class TestApp(unittest.TestCase):
         if os.path.exists(self._dir):
             shutil.rmtree(self._dir)
         db.session.remove()
-        db.drop(test_mode=True)
+        db.drop()
 
     def _get_dummy_result(self):
         r = Result(path_name=self._dir)

--- a/tests/tasks_tests/test_collect_images.py
+++ b/tests/tasks_tests/test_collect_images.py
@@ -23,9 +23,9 @@ class TestApp(unittest.TestCase):
                 'when you run this test'
             )
         db.init()
-        db.setup(test_mode=True)
 
     def setUp(self):
+        db.setup(test_mode=True)
         upgrade_db()
 
         dir = tempfile.mkdtemp(prefix='chainerui_test_collect_images')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,7 +156,6 @@ class TestAPI(unittest.TestCase):
                 'when you run this test'
             )
         db.init()
-        db.setup(test_mode=True)
 
         test_dir = tempfile.mkdtemp(prefix='chainerui_test_api')
         cls._dir = test_dir
@@ -170,6 +169,8 @@ class TestAPI(unittest.TestCase):
             shutil.rmtree(cls._dir)
 
     def setUp(self):
+        db.setup(test_mode=True)
+
         project_name = 'my-project'
         setup_test_db(self._project_path, project_name)
         self._project_name = project_name
@@ -179,7 +180,7 @@ class TestAPI(unittest.TestCase):
         self.app = app.test_client()
 
     def tearDown(self):
-        # remove test db if exists
+        db.session.remove()
         db.drop(test_mode=True)
 
     def assert_test_project(self, project, path=None, name=None):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,7 +155,7 @@ class TestAPI(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
-        db.init()
+        db.init_db()
 
         test_dir = tempfile.mkdtemp(prefix='chainerui_test_api')
         cls._dir = test_dir
@@ -181,7 +181,7 @@ class TestAPI(unittest.TestCase):
 
     def tearDown(self):
         db.session.remove()
-        db.drop(test_mode=True)
+        db.drop()
 
     def assert_test_project(self, project, path=None, name=None):
         assert len(project) == 3

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,6 +155,7 @@ class TestAPI(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
+        db.init()
         db.setup(test_mode=True)
 
         test_dir = tempfile.mkdtemp(prefix='chainerui_test_api')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,6 @@ from chainerui import CHAINERUI_ENV
 from chainerui import create_app
 from chainerui import db
 from chainerui.models.project import Project
-from chainerui import upgrade_db
 from chainerui.utils.commands_state import CommandsState
 from tests.helpers import assert_json_api
 from tests.helpers import NotInTestEnvironmentException
@@ -140,7 +139,7 @@ def setup_test_project(root_path):
 
 
 def setup_test_db(project_path, project_name):
-    upgrade_db()
+    db.upgrade()
 
     # insert test data
     Project.create(project_path, project_name)
@@ -181,7 +180,7 @@ class TestAPI(unittest.TestCase):
 
     def tearDown(self):
         db.session.remove()
-        db.drop()
+        db.remove_db()
 
     def assert_test_project(self, project, path=None, name=None):
         assert len(project) == 3

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,8 +8,7 @@ from six import string_types
 
 from chainerui import CHAINERUI_ENV
 from chainerui import create_app
-from chainerui import create_db
-from chainerui import DB_FILE_PATH
+from chainerui import db
 from chainerui.models.project import Project
 from chainerui import upgrade_db
 from chainerui.utils.commands_state import CommandsState
@@ -141,7 +140,6 @@ def setup_test_project(root_path):
 
 
 def setup_test_db(project_path, project_name):
-    create_db()
     upgrade_db()
 
     # insert test data
@@ -157,6 +155,7 @@ class TestAPI(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
+        db.setup(test_mode=True)
 
         test_dir = tempfile.mkdtemp(prefix='chainerui_test_api')
         cls._dir = test_dir
@@ -180,8 +179,7 @@ class TestAPI(unittest.TestCase):
 
     def tearDown(self):
         # remove test db if exists
-        if os.path.exists(DB_FILE_PATH):
-            os.remove(DB_FILE_PATH)
+        db.drop(test_mode=True)
 
     def assert_test_project(self, project, path=None, name=None):
         assert len(project) == 3

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,6 @@ import unittest
 from chainerui import app
 from chainerui import db
 from chainerui.models.project import Project
-from chainerui import upgrade_db
 
 
 class TestApp(unittest.TestCase):
@@ -22,7 +21,7 @@ class TestApp(unittest.TestCase):
     def tearDown(self):
         if db._session is not None:
             db.session.remove()
-        db.drop()
+        db.remove_db()
         if os.path.exists(self._dir):
             shutil.rmtree(self._dir)
 
@@ -42,7 +41,7 @@ class TestApp(unittest.TestCase):
             args.handler(args)
             f.assert_not_called()
 
-            upgrade_db()
+            db.upgrade()
             args.handler(args)
             f.assert_called_once()
             mock_app.run.assert_called_with(
@@ -57,7 +56,7 @@ class TestApp(unittest.TestCase):
         assert args.db == self._db_url
 
         args.handler(args)
-        upgrade_db()
+        db.upgrade()
         p = db.session.query(Project).filter_by(path_name=self._dir).first()
         assert p is None
         # on Windows/Python2, another session is create, need to remove

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,7 +22,7 @@ class TestApp(unittest.TestCase):
     def tearDown(self):
         if db._session is not None:
             db.session.remove()
-        db.drop(test_mode=True)
+        db.drop()
         if os.path.exists(self._dir):
             shutil.rmtree(self._dir)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,7 +20,9 @@ class TestApp(unittest.TestCase):
         self._db_url = 'sqlite:///' + self._db_path
 
     def tearDown(self):
-        db.session.remove()
+        if db._session is not None:
+            db.session.remove()
+        db.drop(test_mode=True)
         if os.path.exists(self._dir):
             shutil.rmtree(self._dir)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,14 +11,6 @@ from chainerui.models.project import Project
 from chainerui import upgrade_db
 
 
-def _return_true():
-    return True
-
-
-def _return_false():
-    return False
-
-
 class TestApp(unittest.TestCase):
 
     def setUp(self):
@@ -28,6 +20,7 @@ class TestApp(unittest.TestCase):
         self._db_url = 'sqlite:///' + self._db_path
 
     def tearDown(self):
+        db.session.remove()
         if os.path.exists(self._dir):
             shutil.rmtree(self._dir)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -60,12 +60,16 @@ class TestApp(unittest.TestCase):
         upgrade_db()
         p = db.session.query(Project).filter_by(path_name=self._dir).first()
         assert p is None
+        # on Windows/Python2, another session is create, need to remove
+        # this session externally (*)
+        db._session.remove()
 
         args.handler(args)
         p = db.session.query(Project).filter_by(path_name=self._dir).first()
         assert p is not None
         assert p.path_name == self._dir
         assert p.name == 'test'
+        db._session.remove()  # same as (*)
 
         args.handler(args)  # already registered, confirm not occur error
         ps = db.session.query(Project).filter_by(path_name=self._dir).all()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,10 +1,12 @@
+from mock import MagicMock
 import unittest
+
+from six import string_types
+from sqlalchemy.exc import OperationalError
 
 from chainerui import CHAINERUI_ENV
 from chainerui import create_app
-
-from six import string_types
-
+from chainerui import db
 from tests.helpers import assert_json_api
 from tests.helpers import NotInTestEnvironmentException
 
@@ -21,6 +23,12 @@ class TestInit(unittest.TestCase):
 
     def setUp(self):
         # not setup database
+        db._initialized = True
+        mock_session = MagicMock()
+        mock_session.query = MagicMock(
+            side_effect=OperationalError(None, None, None))
+        db._session = mock_session
+
         app = create_app()
         app.testing = True
         self.app = app.test_client()

--- a/tests/utils_tests/test_db_revision.py
+++ b/tests/utils_tests/test_db_revision.py
@@ -20,6 +20,7 @@ class DBRevision(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
+        db.init()
         db.setup(test_mode=True)
 
     @classmethod

--- a/tests/utils_tests/test_db_revision.py
+++ b/tests/utils_tests/test_db_revision.py
@@ -4,8 +4,6 @@ from alembic.command import upgrade
 
 from chainerui import CHAINERUI_ENV
 from chainerui import db
-from chainerui import get_db_migration_config
-from chainerui import upgrade_db
 from chainerui.utils.db_revision import check_current_db_revision
 
 from tests.helpers import NotInTestEnvironmentException
@@ -26,10 +24,10 @@ class DBRevision(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         db.session.remove()
-        db.drop()
+        db.remove_db()
 
     def _upgrade(self):
-        config = get_db_migration_config()
+        config = db.alembic_config
         upgrade(config, '213e2a3392f2')  # = init revision
 
     def test_check_current_db_revision(self):
@@ -38,5 +36,5 @@ class DBRevision(unittest.TestCase):
         self._upgrade()
         assert not check_current_db_revision()
 
-        upgrade_db()
+        db.upgrade()
         assert check_current_db_revision()

--- a/tests/utils_tests/test_db_revision.py
+++ b/tests/utils_tests/test_db_revision.py
@@ -20,13 +20,13 @@ class DBRevision(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
-        db.init()
+        db.init_db()
         db.setup(test_mode=True)
 
     @classmethod
     def tearDownClass(cls):
         db.session.remove()
-        db.drop(test_mode=True)
+        db.drop()
 
     def _upgrade(self):
         config = get_db_migration_config()

--- a/tests/utils_tests/test_db_revision.py
+++ b/tests/utils_tests/test_db_revision.py
@@ -25,6 +25,7 @@ class DBRevision(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        db.session.remove()
         db.drop(test_mode=True)
 
     def _upgrade(self):

--- a/tests/utils_tests/test_db_revision.py
+++ b/tests/utils_tests/test_db_revision.py
@@ -1,11 +1,9 @@
-import os
 import unittest
 
 from alembic.command import upgrade
 
 from chainerui import CHAINERUI_ENV
-from chainerui import create_db
-from chainerui import DB_FILE_PATH
+from chainerui import db
 from chainerui import get_db_migration_config
 from chainerui import upgrade_db
 from chainerui.utils.db_revision import check_current_db_revision
@@ -22,20 +20,17 @@ class DBRevision(unittest.TestCase):
                 'set environment variable CHAINERUI_ENV=test '
                 'when you run this test'
             )
+        db.setup(test_mode=True)
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists(DB_FILE_PATH):
-            os.remove(DB_FILE_PATH)
+        db.drop(test_mode=True)
 
     def _upgrade(self):
         config = get_db_migration_config()
         upgrade(config, '213e2a3392f2')  # = init revision
 
     def test_check_current_db_revision(self):
-        assert not check_current_db_revision()
-
-        create_db()
         assert not check_current_db_revision()
 
         self._upgrade()


### PR DESCRIPTION
This PR is for supporting other DB, such as MySQL or PostgreSQL

- split `DB_*` to `chainerui.db`
  - DB engine and session are set in `chainerui.db`
- add `--db` option, ex: `chainerui --db <db-url> server`
  - if `--db` is empty, use SQLite
- fix miner bug
  - [wrong table name](https://github.com/chainer/chainerui/blob/c75f394a8f2e60b028c9d337ecac5255449953ec/chainerui/migration/versions/4e779a5fc57e_add_is_unregistered_to_result.py#L26)
- refactoring `test_app.py`, simplified

I'll sent another PR

- document
- add test using other DB