### PR TITLE
Replace logging system on server side

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 
 before_install:
   - pip install autopep8 hacking
-  - pip install pytest-cov coveralls
+  - pip install -U pytest pytest-cov coveralls
   - pip install Pillow
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install mock; fi
   - npm install -g npm@6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - python --version
   - pip --version
 
-  - pip install pytest-cov mock
+  - pip install -U pytest pytest-cov mock
   - pip install Pillow
 
   # Update Node.js

--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -3,8 +3,8 @@ import os
 
 from flask import Flask
 from flask import jsonify
-from flask import request
 from flask import render_template
+from flask import request
 from flask import send_from_directory
 from flask import url_for
 from sqlalchemy.exc import OperationalError
@@ -82,9 +82,9 @@ def create_app():
     def output_log(response):
         now = datetime.datetime.now()
         log_msg = '%s - - [%s] "%s %s %s" %d' % (
-                request.remote_addr, now.replace(microsecond=0),
-                request.method, request.full_path,
-                request.environ.get('SERVER_PROTOCOL'), response.status_code)
+            request.remote_addr, now.replace(microsecond=0),
+            request.method, request.full_path,
+            request.environ.get('SERVER_PROTOCOL'), response.status_code)
         if response.content_length is not None:
             log_msg += ' %d' % response.content_length
         if request._comming_at is not None:

--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import datetime
 import os
 
@@ -25,7 +26,8 @@ def create_app():
 
     app = Flask(__name__)
     app.logger.disabled = True
-    app.logger.handlers.clear()
+    for h in app.logger.handlers[:]:
+        app.logger.removeHandler(h)
     app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
     def dated_url_for(endpoint, **values):

--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -25,6 +25,7 @@ def create_app():
 
     app = Flask(__name__)
     app.logger.disabled = True
+    app.logger.handlers.clear()
     app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
     def dated_url_for(endpoint, **values):

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import argparse
 import logging
 import os

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -51,7 +51,7 @@ def _show_banner_debug(app, listener):
         logger.info(' * Environment: {}'.format(app.config['ENV']))
         logger.info(' * Debug mode: on')
         logger.info(' * Running on http://{}/ (Press CTRL+C to quit)'.format(
-                listener))
+            listener))
 
 
 def server_handler(args):
@@ -88,7 +88,7 @@ def server_handler(args):
 
         logger.info(' * Environment: {}'.format(app.config['ENV']))
         logger.info(' * Running on http://{}/ (Press CTRL+C to quit)'.format(
-                listener))
+            listener))
 
         try:
             http_server.serve_forever()

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -77,6 +77,7 @@ def server_handler(args):
             args.host, args.port, app, use_reloader=True, use_debugger=True,
             threaded=True)
     else:
+        app.config['ENV'] = 'production'
         import gevent
         from gevent.pywsgi import WSGIServer
         http_server = WSGIServer(listener, application=app, log=None)
@@ -87,7 +88,6 @@ def server_handler(args):
 
         gevent.signal(signal.SIGTERM, stop_server)
         gevent.signal(signal.SIGINT, stop_server)
-
         logger.info(' * Environment: {}'.format(app.config['ENV']))
         logger.info(' * Running on http://{}/ (Press CTRL+C to quit)'.format(
             listener))

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -39,7 +39,7 @@ def _show_banner_debug(app, listener):
     # server started.
     from werkzeug.serving import is_running_from_reloader
     if is_running_from_reloader():
-        # On debut mode, the banner is shown every reloaded.
+        # On debug mode, the banner is shown every reloaded.
         # run_simple set reloader type as 'stat' on default
         logger.info(' * Restarning with stat')
         # level warning is followed by werkzeug implementation

--- a/chainerui/logging.py
+++ b/chainerui/logging.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 import threading
 

--- a/chainerui/logging.py
+++ b/chainerui/logging.py
@@ -11,7 +11,7 @@ _logger = None
 
 
 def _get_library_logger():
-    return logging.getLogger('chainerui')
+    return logging.getLogger(__name__)
 
 
 def set_loglevel(level):
@@ -43,7 +43,7 @@ def get_logger():
             own_logger.addHandler(handler)
 
         own_logger.setLevel(logging.INFO)
-        _logger = structlog.get_logger('chainerui')
+        _logger = structlog.get_logger(__name__)
     return _logger
 
 

--- a/chainerui/logging.py
+++ b/chainerui/logging.py
@@ -1,0 +1,47 @@
+import logging
+import threading
+
+import structlog
+
+
+_mutex = threading.Lock()
+_logger = None
+
+
+def _get_library_logger():
+    return logging.getLogger('chainerui')
+
+
+def set_loglevel(level):
+    _get_library_logger().setLevel(level)
+
+
+def get_logger():
+    global _logger
+
+    with _mutex:
+        if _logger is not None:
+            return _logger
+
+        structlog.configure(
+            processors=[
+                structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+            ],
+            logger_factory=structlog.stdlib.LoggerFactory(),
+        )
+
+        if not logging.getLogger().handlers:
+            # own hander is set only when python root logger is not setup
+            formatter = structlog.stdlib.ProcessorFormatter(
+                processor=structlog.dev.ConsoleRenderer(colors=False),
+            )
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            own_logger = _get_library_logger()
+            own_logger.addHandler(handler)
+            own_logger.setLevel(logging.INFO)
+        _logger = structlog.get_logger('chainerui')
+    return _logger
+
+
+logger = get_logger()

--- a/chainerui/logging.py
+++ b/chainerui/logging.py
@@ -24,7 +24,6 @@ def get_logger():
     with _mutex:
         if _logger is not None:
             return _logger
-
         structlog.configure(
             processors=[
                 structlog.stdlib.ProcessorFormatter.wrap_for_formatter,

--- a/chainerui/logging.py
+++ b/chainerui/logging.py
@@ -30,6 +30,7 @@ def get_logger():
             logger_factory=structlog.stdlib.LoggerFactory(),
         )
 
+        own_logger = _get_library_logger()
         if not logging.getLogger().handlers:
             # own hander is set only when python root logger is not setup
             formatter = structlog.stdlib.ProcessorFormatter(
@@ -37,9 +38,9 @@ def get_logger():
             )
             handler = logging.StreamHandler()
             handler.setFormatter(formatter)
-            own_logger = _get_library_logger()
             own_logger.addHandler(handler)
-            own_logger.setLevel(logging.INFO)
+
+        own_logger.setLevel(logging.INFO)
         _logger = structlog.get_logger('chainerui')
     return _logger
 

--- a/chainerui/tasks/crawl_result.py
+++ b/chainerui/tasks/crawl_result.py
@@ -3,6 +3,7 @@ import json
 import os
 
 from chainerui import db
+from chainerui import logger
 from chainerui.models.argument import Argument
 from chainerui.models.command import Command
 from chainerui.models.log import Log
@@ -20,7 +21,8 @@ def load_result_json(result_path, json_file_name):
             try:
                 _list = json.load(json_data)
             except ValueError as err:
-                print("Failed to load json: {}, {}".format(json_path, err))
+                logger.error(
+                    'Failed to load json: {}, {}'.format(json_path, err))
 
     return _list
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sqlalchemy>=1.1.14
 alembic>=0.9.5
 chainer>=3.0.0
 gevent>=1.2.0
+structlog>=18.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test
 python_functions = test
-minversion = 2.9
+minversion = 3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test
 python_functions = test
-minversion = 3.3
+minversion = 3.4

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -69,9 +69,6 @@ class TestApp(unittest.TestCase):
             db.upgrade()
             args.handler(args)
             mock_server.serve_forever.assert_called_once()
-            mock_server.serve_forever(
-                'test.domain', 5001, mock_app, use_reloader=True,
-                use_debugger=True, threaded=True)
 
     def test_project_create(self):
         args = app.create_parser().parse_args(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -15,10 +15,11 @@ def test_get_logger_with_pytest_default(caplog):
     logger.info('info')
     logger.debug('debug')
 
-    texts = caplog.text
-    assert "{'event': 'error'}" in texts
-    assert "{'event': 'info'}" in texts
-    assert 'debug' not in texts
+    assert len(caplog.records) == 2
+    assert 'event' in caplog.records[0].message
+    assert "error" in caplog.records[0].message
+    assert 'event' in caplog.records[1].message
+    assert 'info' in caplog.records[1].message
 
 
 def test_get_logger_with_own_handler(capsys):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -34,6 +34,13 @@ def test_get_logger_with_pytest_default(caplog):
     assert 'event' in caplog.records[1].message
     assert 'info' in caplog.records[1].message
 
+    logging_util.set_loglevel(logging.DEBUG)
+    logger2 = get_logger()
+    logger2.debug('debug')
+    assert len(caplog.records) == 3
+    assert 'event' in caplog.records[2].message
+    assert 'debug' in caplog.records[2].message
+
 
 def test_get_logger_with_own_handler(capsys):
     # reset pytest logging capture

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,51 @@
+from chainerui.logging import get_logger
+
+
+def test_get_logger_with_pytest_default(caplog):
+    import logging
+    caplog.set_level(logging.INFO)
+
+    # other test suite has already called chainerui.logger, so need to reset
+    # library logger
+    import chainerui.logging as logging_util
+    logging_util._logger = None
+    logger = get_logger()
+
+    logger.error('error')
+    logger.info('info')
+    logger.debug('debug')
+
+    texts = caplog.text
+    assert "{'event': 'error'}" in texts
+    assert "{'event': 'info'}" in texts
+    assert 'debug' not in texts
+
+
+def test_get_logger_with_own_handler(capsys):
+    # reset pytest logging capture
+    import logging
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        for handler in root_logger.handlers:
+            root_logger.removeHandler(handler)
+
+    # other test suite has already called chainerui.logger, so need to reset
+    # library logger
+    import chainerui.logging as logging_util
+    logging_util._logger = None
+    logger = get_logger()
+
+    logger.error('error')
+    logger.info('info')
+    logger.debug('debug')
+
+    _, err = capsys.readouterr()
+    assert 'event' not in err
+    assert 'error' in err
+    assert 'info' in err
+    assert 'debug' not in err
+
+    logging_util.set_loglevel(logging.DEBUG)
+    logger.debug('debug')
+    _, err2 = capsys.readouterr()
+    assert 'debug' in err2


### PR DESCRIPTION
ChainerUI uses Flask's default logging system, this causes unable to control logging style and output format. This PR introduces own logger to control logging system. ChainerUI will apply structured logging in future, but at first, this PR (almost) maintains current log format.

**Changed points**

- Omit application name and eager mode log sentence on debug mode. 
  - example: ` * Serving Flask app "chainerui" (lazy loading)`
- add content length and response time on debug mode.
  - these numbers have been viewed on production mode.

This PR replaced logging using `print` function only on server side, `print` has still remain on client logging such as `chainerui db create`.