### PR TITLE
Add connection checker to external DB

### DIFF
--- a/chainerui/database.py
+++ b/chainerui/database.py
@@ -61,7 +61,7 @@ class Database(object):
                 connect_args=connect_args,
                 echo=echo
             )
-        except ModuleNotFoundError as e:
+        except ImportError as e:
             print(e, ', Please install the driver to support the external DB')
             return False
         self._engine = engine


### PR DESCRIPTION
avoid to print stacktrace on the following cases.

- not install DB driver
- cannot connect to DB