### PR TITLE
Add word-break into ExperimentsTableConfigurator

### DIFF
--- a/frontend/src/components/ExperimentsTableConfigurator.jsx
+++ b/frontend/src/components/ExperimentsTableConfigurator.jsx
@@ -89,7 +89,7 @@ class ExperimentsTableConfigurator extends React.Component {
               {
                 logKeys.map((l) => (
                   <FormGroup check key={`logKey.${l}`}>
-                    <Label check>
+                    <Label check className="form-check-label-break-word">
                       <Input
                         type="checkbox"
                         name={l}
@@ -106,7 +106,7 @@ class ExperimentsTableConfigurator extends React.Component {
               {
                 argKeys.map((a) => (
                   <FormGroup check key={`argKey.${a}`}>
-                    <Label check>
+                    <Label check className="form-check-label-break-word">
                       <Input
                         type="checkbox"
                         name={a}


### PR DESCRIPTION
Before:
<img width="578" alt="2018-10-05 15 55 45" src="https://user-images.githubusercontent.com/280562/46520725-ff253900-c8b7-11e8-863b-4488e1d603cc.png">

After:
<img width="520" alt="2018-10-05 15 59 05" src="https://user-images.githubusercontent.com/280562/46520719-faf91b80-c8b7-11e8-8e45-e497c062dfe1.png">

ref. #179