### PR TITLE
[WIP] Refactoring, run pytest without environment variable

### DIFF
--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -18,9 +18,6 @@ from chainerui.logging import logger
 __version__ = _version.__version__
 
 
-CHAINERUI_ENV = os.getenv('CHAINERUI_ENV', 'production')
-
-
 def create_app():
     """create_app."""
 

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -15,9 +15,8 @@ from chainerui.models.project import Project
 from chainerui.utils import db_revision
 
 
-def _setup_db(db_url):
+def _setup_db(db_url, echo=False):
     test_mode = CHAINERUI_ENV == 'test'
-    echo = CHAINERUI_ENV == 'development'
     return db.setup(url=db_url, test_mode=test_mode, echo=echo)
 
 
@@ -57,7 +56,7 @@ def _show_banner_debug(app, listener):
 
 def server_handler(args):
     """server_handler."""
-    if not _setup_db(args.db):
+    if not _setup_db(args.db, args.db_echo):
         return
     if not _check_db_revision():
         return
@@ -105,7 +104,7 @@ def db_handler(args):
             db.init_db()
         return
 
-    if not _setup_db(args.db):
+    if not _setup_db(args.db, args.db_echo):
         return
 
     if args.type == 'status':
@@ -126,7 +125,7 @@ def db_handler(args):
 
 def project_create_handler(args):
     """project_create_handler."""
-    if not _setup_db(args.db):
+    if not _setup_db(args.db, args.db_echo):
         return
     if not _check_db_revision():
         return
@@ -150,6 +149,9 @@ def create_parser():
     parser.add_argument(
         '--db', help='database resource address',
         default=os.getenv('CHAINERUI_DB_URL', default=None))
+    parser.add_argument(
+        '--db-echo', help='enable database enginge logging',
+        action='store_true')
     subparsers = parser.add_subparsers()
 
     # chainerui server

--- a/chainerui/app.py
+++ b/chainerui/app.py
@@ -6,18 +6,12 @@ import os
 import signal
 
 from chainerui import _version
-from chainerui import CHAINERUI_ENV
 from chainerui import create_app
 from chainerui import db
 from chainerui import logger
 from chainerui.logging import set_loglevel
 from chainerui.models.project import Project
 from chainerui.utils import db_revision
-
-
-def _setup_db(db_url, echo=False):
-    test_mode = CHAINERUI_ENV == 'test'
-    return db.setup(url=db_url, test_mode=test_mode, echo=echo)
 
 
 def _check_db_revision():
@@ -56,7 +50,7 @@ def _show_banner_debug(app, listener):
 
 def server_handler(args):
     """server_handler."""
-    if not _setup_db(args.db, args.db_echo):
+    if not db.setup(url=args.db, echo=args.db_echo):
         return
     if not _check_db_revision():
         return
@@ -104,7 +98,7 @@ def db_handler(args):
             db.init_db()
         return
 
-    if not _setup_db(args.db, args.db_echo):
+    if not db.setup(url=args.db, echo=args.db_echo):
         return
 
     if args.type == 'status':
@@ -125,7 +119,7 @@ def db_handler(args):
 
 def project_create_handler(args):
     """project_create_handler."""
-    if not _setup_db(args.db, args.db_echo):
+    if not db.setup(url=args.db, echo=args.db_echo):
         return
     if not _check_db_revision():
         return

--- a/chainerui/database.py
+++ b/chainerui/database.py
@@ -38,11 +38,10 @@ class Database(object):
                 raise
         print('DB file path:', db_dir)
 
-    def setup(self, url=None, test_mode=False, echo=False):
+    def setup(self, url=None, echo=False):
         if url is None:
             db_dir = self._sqlite_default_db_dir()
-            db_file_name = 'chainerui_test.db' if test_mode else 'chainerui.db'
-            db_path = os.path.join(db_dir, db_file_name)
+            db_path = os.path.join(db_dir, 'chainerui.db')
             self._sqlite_db_file_path = db_path
             url = 'sqlite:///' + db_path
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import tempfile
 
 import pytest
 
+from chainerui import create_app
+from chainerui import db
+
 
 @pytest.fixture(scope='session')
 def base_dir():
@@ -43,3 +46,27 @@ class TempDirTestCase(object):
         test_dir = _make_new_directory(func_base)
 
         self.dir = test_dir
+
+
+@pytest.fixture(scope='function')
+def app():
+    app = create_app()
+    app.testing = True
+    return app.test_client()
+
+
+@pytest.fixture(scope='function')
+def func_init_db(func_dir):
+    url = 'sqlite:///' + os.path.join(func_dir, 'chainerui.db')
+    db.setup(url=url, echo=False)
+
+    yield
+
+    if db._session is not None:
+        db.session.remove()
+    db.remove_db()
+
+
+@pytest.fixture(scope='function')
+def func_db(func_init_db):
+    db.upgrade()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+import tempfile
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def base_dir():
+    base = tempfile.mkdtemp(prefix='chainerui_test_')
+    yield(base)
+    shutil.rmtree(base)
+
+
+def _make_new_directory(base):
+    # when the function is run with parameterized test, the 'test_dir' has
+    # already created, so create another directory with sequential ID
+    seq_id = -1
+    new_dir = base
+    while True:
+        if not os.path.exists(new_dir):
+            break
+        seq_id += 1
+        new_dir = '{}_{:d}'.format(base, seq_id)
+    os.makedirs(new_dir)
+    return new_dir
+
+
+@pytest.fixture(autouse=True, scope='function')
+def func_dir(request, base_dir):
+    func_name = request.function.__name__
+    func_base = os.path.join(base_dir, func_name)
+    return _make_new_directory(func_base)
+
+
+class TempDirTestCase(object):
+
+    @pytest.fixture(autouse=True, scope='function')
+    def make_method_dir(self, request, base_dir):
+        cls_name = request.cls.__name__
+        func_name = request.function.__name__
+        func_base = os.path.join(base_dir, cls_name, func_name)
+        test_dir = _make_new_directory(func_base)
+
+        self.dir = test_dir

--- a/tests/extensions_tests/test_commands_extension.py
+++ b/tests/extensions_tests/test_commands_extension.py
@@ -1,18 +1,17 @@
 from mock import MagicMock
 import os
-import shutil
-import tempfile
-import unittest
 
 from chainer.optimizer import Hyperparameter
 from chainer.training import Trainer
 from chainer.training.triggers import IntervalTrigger
+import pytest
 
 from chainerui.extensions.commands_extension import _stop_training
 from chainerui.extensions.commands_extension import CommandsExtension
 from chainerui.utils.command_item import CommandItem
 from chainerui.utils.commands_state import CommandsState
 from chainerui.utils.commands_state import JobStatus
+from tests.conftest import TempDirTestCase
 
 
 class _MockTrainer(Trainer):
@@ -42,18 +41,10 @@ class _MockTrainer(Trainer):
         pass
 
 
-class TestCommandsExtension(unittest.TestCase):
-
-    def setUp(self):
-        test_dir = tempfile.mkdtemp(prefix='chainerui_test_cmdext')
-        self._dir = test_dir
-
-    def tearDown(self):
-        if os.path.exists(self._dir):
-            shutil.rmtree(self._dir)
+class TestCommandsExtension(TempDirTestCase):
 
     def test_initialize_command_trigger(self):
-        out_path = os.path.join(self._dir, 'results')
+        out_path = os.path.join(self.dir, 'results')
         os.makedirs(out_path)
         commands_path = os.path.join(out_path, 'commands')
         open(commands_path, 'w').close()
@@ -75,15 +66,15 @@ class TestCommandsExtension(unittest.TestCase):
         target.add_receiver('f', f)
         assert 'f' in target._receivers
 
-        with self.assertRaises(ValueError) as e:
+        with pytest.raises(ValueError) as e:
             target.add_receiver(None, None)
-        assert 'not given' in str(e.exception)
-        with self.assertRaises(ValueError) as e:
+        assert 'not given' in str(e.value)
+        with pytest.raises(ValueError) as e:
             target.add_receiver('f', 0)
-        assert 'not callable' in str(e.exception)
+        assert 'not callable' in str(e.value)
 
     def test_call(self):
-        out_path = os.path.join(self._dir, 'results')
+        out_path = os.path.join(self.dir, 'results')
         os.makedirs(out_path)
         commands_path = os.path.join(out_path, 'commands')
         open(commands_path, 'w').close()
@@ -172,7 +163,7 @@ class TestCommandsExtension(unittest.TestCase):
         assert CommandsState.job_status(out_path) == JobStatus.STOPPED
 
     def test_call_invalid_request(self):
-        out_path = os.path.join(self._dir, 'results')
+        out_path = os.path.join(self.dir, 'results')
         os.makedirs(out_path)
         commands_path = os.path.join(out_path, 'commands')
         open(commands_path, 'w').close()

--- a/tests/extensions_tests/test_image_reporter_extension.py
+++ b/tests/extensions_tests/test_image_reporter_extension.py
@@ -1,8 +1,6 @@
 import json
 from mock import MagicMock
 import os
-import shutil
-import tempfile
 import unittest
 import warnings
 
@@ -11,18 +9,10 @@ import numpy as np
 from chainerui.extensions import image_reporter_extension
 from chainerui.extensions.image_reporter_extension import ImageReport
 from chainerui import summary
+from tests.conftest import TempDirTestCase
 
 
-class TestImageReport(unittest.TestCase):
-
-    def setUp(self):
-        test_dir = tempfile.mkdtemp(prefix='chainerui_test_imgreport')
-        self._dir = test_dir
-
-    def tearDown(self):
-        summary.chainerui_image_observer.observation = {}
-        if os.path.exists(self._dir):
-            shutil.rmtree(self._dir)
+class TestImageReport(TempDirTestCase):
 
     def _make_trainer_mock(self, epoch, iteration):
         updater = MagicMock()
@@ -30,7 +20,7 @@ class TestImageReport(unittest.TestCase):
         updater.epoch_detail = epoch
         updater.iteration = iteration
         trainer = MagicMock()
-        trainer.out = self._dir
+        trainer.out = self.dir
         trainer.updater = updater
         return trainer
 
@@ -99,20 +89,20 @@ class TestImageReport(unittest.TestCase):
         target(trainer)
         assert len(target._infos) == 1
         png1_name = 'iter_100_%s.png' % target._get_hash('name1')
-        png1_path = os.path.join(self._dir, png1_name)
+        png1_path = os.path.join(self.dir, png1_name)
         assert os.path.exists(png1_path)
         loaded_img1 = Image.open(png1_path)
         expected_img1 = Image.fromarray(img1, mode='HSV').convert('RGB')
         assert self._equal_image(loaded_img1, expected_img1)
         png2_name = 'iter_100_%s.png' % target._get_hash('name2')
-        png2_path = os.path.join(self._dir, png2_name)
+        png2_path = os.path.join(self.dir, png2_name)
         assert os.path.exists(png2_path)
         loaded_img2 = Image.open(png2_path)
         expected_img2 = Image.fromarray(img2)
         assert self._equal_image(loaded_img2, expected_img2)
 
         # confirm metadata
-        info_path = os.path.join(self._dir, target._info_name)
+        info_path = os.path.join(self.dir, target._info_name)
         assert os.path.exists(info_path)
         with open(info_path, 'r') as f:
             info = json.load(f)
@@ -148,13 +138,13 @@ class TestImageReport(unittest.TestCase):
         target(trainer)
         assert len(target._infos) == 2
         png3_name = 'iter_200_%s.png' % target._get_hash('name1')
-        png3_path = os.path.join(self._dir, png3_name)
+        png3_path = os.path.join(self.dir, png3_name)
         assert os.path.exists(png3_path)
         loaded_img3 = Image.open(png3_path)
         expected_img3 = Image.fromarray(target._normalize_8bit(img3))
         assert self._equal_image(loaded_img3, expected_img3)
         png4_name = 'iter_200_%s.png' % target._get_hash('name2')
-        png4_path = os.path.join(self._dir, png4_name)
+        png4_path = os.path.join(self.dir, png4_name)
         assert os.path.exists(png4_path)
         loaded_img4 = Image.open(png4_path)
         expected_img4 = Image.fromarray(img2)
@@ -194,7 +184,7 @@ class TestImageReport(unittest.TestCase):
         target(trainer)
         assert len(target._infos) == 1
         png_name = 'iter_10_%s.png' % target._get_hash('test')
-        png_path = os.path.join(self._dir, png_name)
+        png_path = os.path.join(self.dir, png_name)
         assert os.path.exists(png_path)
         loaded_img = Image.open(png_path)
         expected_img = Image.fromarray(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,10 +1,6 @@
 import json
 
 
-class NotInTestEnvironmentException(Exception):
-    pass
-
-
 def is_valid_json_str(json_str):
     try:
         json.loads(json_str)

--- a/tests/migration_tests/versions_tests/test_alter_log_data_type.py
+++ b/tests/migration_tests/versions_tests/test_alter_log_data_type.py
@@ -1,85 +1,66 @@
 from contextlib import closing
 import json
+import os
 import sqlite3
-import unittest
 
 import alembic
 import msgpack
 
-from chainerui import CHAINERUI_ENV
 from chainerui import db
 from chainerui.migration.versions import e3db52a480f8_alter_log_data_type as target  # NOQA
-from tests.helpers import NotInTestEnvironmentException
 
 
-class TestUpgrade(unittest.TestCase):
+def _upgrade_before_revision(alembic_config):
+    script_dir = alembic.script.ScriptDirectory.from_config(alembic_config)
+    revisions = [sc.revision for sc in
+                 script_dir.walk_revisions('base', target.revision)][::-1]
+    for rev in revisions[:-1]:
+        alembic.command.upgrade(alembic_config, rev)
 
-    @classmethod
-    def setUpClass(cls):
-        if not CHAINERUI_ENV == 'test':
-            raise NotInTestEnvironmentException(
-                'set environment variable CHAINERUI_ENV=test '
-                'when you run this test'
-            )
-        db.init_db()
-        db.setup(test_mode=True)
-        cls.db_file_path = db._sqlite_db_file_path
 
-        config = db.alembic_config
-        cls._config = config
+def test_upgrade_downgrade(func_dir, func_init_db):
+    # NOTE: don't use alembic operation module, the module is not
+    #       initialized before calling upgrade command.
+    _upgrade_before_revision(db.alembic_config)
+    db_file_path = os.path.join(func_dir, 'chainerui.db')
 
-        script_dir = alembic.script.ScriptDirectory.from_config(config)
-        revisions = [sc.revision for sc in
-                     script_dir.walk_revisions('base', target.revision)][::-1]
-        for rev in revisions[:-1]:
-            alembic.command.upgrade(config, rev)
+    with closing(sqlite3.connect(db_file_path)) as conn:
+        c = conn.cursor()
+        insert_sql = 'INSERT INTO log (id, result_id, data) VALUES (?, ?, ?)'
 
-    @classmethod
-    def tearDownClass(cls):
-        db.session.remove()
-        db.remove_db()
+        data1 = {'epoch': 1, 'iterations': 1, 'elapsed_time': 10}
+        log1 = (0, 0, json.dumps(data1))
+        data2 = {'epoch': 1, 'iterations': 2, 'elapsed_time': 20}
+        log2 = (1, 0, json.dumps(data2))
+        c.executemany(insert_sql, [log1, log2])
+        conn.commit()
 
-    def test_upgrade_downgrade(self):
-        # NOTE: don't use alembic operation module, the module is not
-        #       initialized before calling upgrade command.
-        with closing(sqlite3.connect(self.db_file_path)) as conn:
-            c = conn.cursor()
-            insert_sql = 'INSERT INTO log (id, result_id, data) VALUES ' +\
-                         '(?, ?, ?)'
+    alembic.command.upgrade(db.alembic_config, target.revision)
 
-            data1 = {'epoch': 1, 'iterations': 1, 'elapsed_time': 10}
-            log1 = (0, 0, json.dumps(data1))
-            data2 = {'epoch': 1, 'iterations': 2, 'elapsed_time': 20}
-            log2 = (1, 0, json.dumps(data2))
-            c.executemany(insert_sql, [log1, log2])
-            conn.commit()
+    with closing(sqlite3.connect(db_file_path)) as conn:
+        c = conn.cursor()
+        select_sql = 'SELECT id, result_id, data FROM log ORDER BY id'
+        rows = c.execute(select_sql).fetchall()
+        assert len(rows) == 2
+        log1 = rows[0]
+        assert len(log1) == 3
+        data1 = msgpack.unpackb(log1[2], encoding='utf-8')
+        assert len(data1) == 3
+        assert data1['epoch'] == 1
+        assert data1['iterations'] == 1
+        assert data1['elapsed_time'] == 10
 
-        alembic.command.upgrade(self._config, target.revision)
+    alembic.command.downgrade(db.alembic_config, target.down_revision)
 
-        with closing(sqlite3.connect(self.db_file_path)) as conn:
-            c = conn.cursor()
-            select_sql = 'SELECT id, result_id, data FROM log ORDER BY id'
-            rows = c.execute(select_sql).fetchall()
-            assert len(rows) == 2
-            log1 = rows[0]
-            assert len(log1) == 3
-            data1 = msgpack.unpackb(log1[2], encoding='utf-8')
-            assert len(data1) == 3
-            assert data1['epoch'] == 1
-            assert data1['iterations'] == 1
-            assert data1['elapsed_time'] == 10
-
-        alembic.command.downgrade(self._config, target.down_revision)
-
-        with closing(sqlite3.connect(self.db_file_path)) as conn:
-            c = conn.cursor()
-            select_sql = 'SELECT id, result_id, data FROM log ORDER BY id'
-            rows = c.execute(select_sql).fetchall()
-            assert len(rows) == 2
-            log1 = rows[0]
-            assert len(log1) == 3
-            data1 = json.loads(log1[2])
-            assert len(data1) == 3
-            assert data1['epoch'] == 1
-            assert data1['iterations'] == 1
-            assert data1['elapsed_time'] == 10
+    with closing(sqlite3.connect(db_file_path)) as conn:
+        c = conn.cursor()
+        select_sql = 'SELECT id, result_id, data FROM log ORDER BY id'
+        rows = c.execute(select_sql).fetchall()
+        assert len(rows) == 2
+        log1 = rows[0]
+        assert len(log1) == 3
+        data1 = json.loads(log1[2])
+        assert len(data1) == 3
+        assert data1['epoch'] == 1
+        assert data1['iterations'] == 1
+        assert data1['elapsed_time'] == 10

--- a/tests/models_tests/test_result.py
+++ b/tests/models_tests/test_result.py
@@ -89,8 +89,8 @@ def get_test_result(path_name):
     (7, range(7)),
     (100, range(7)),
 ])
-def test_sampled_logs(tmpdir, logs_limit, expected_indices):
-    result = get_test_result(str(tmpdir))
+def test_sampled_logs(func_dir, logs_limit, expected_indices):
+    result = get_test_result(str(func_dir))
     logs = result.logs
     sampled_logs = result.sampled_logs(logs_limit)
     assert len(sampled_logs) == len(expected_indices)

--- a/tests/tasks_tests/test_collect_images.py
+++ b/tests/tasks_tests/test_collect_images.py
@@ -1,9 +1,8 @@
 from collections import OrderedDict
 import json
 import os
-import shutil
-import tempfile
-import unittest
+
+import pytest
 
 from chainerui import CHAINERUI_ENV
 from chainerui import db
@@ -12,176 +11,176 @@ from chainerui.tasks import collect_images
 from tests.helpers import NotInTestEnvironmentException
 
 
-class TestApp(unittest.TestCase):
+@pytest.fixture(autouse=True, scope='module')
+def temp_db():
+    if not CHAINERUI_ENV == 'test':
+        raise NotInTestEnvironmentException(
+            'set environment variable CHAINERUI_ENV=test '
+            'when you run this test'
+        )
+    db.init_db()
 
-    @classmethod
-    def setUpClass(cls):
-        if not CHAINERUI_ENV == 'test':
-            raise NotInTestEnvironmentException(
-                'set environment variable CHAINERUI_ENV=test '
-                'when you run this test'
-            )
-        db.init_db()
 
-    def setUp(self):
-        db.setup(test_mode=True)
-        db.upgrade()
+@pytest.fixture(autouse=True, scope='function')
+def result_path(func_dir):
+    db.setup(test_mode=True)
+    db.upgrade()
 
-        dir = tempfile.mkdtemp(prefix='chainerui_test_collect_images')
-        info_path = os.path.join(dir, '.chainerui_images')
+    info_path = os.path.join(func_dir, '.chainerui_images')
 
-        with open(os.path.join(dir, 'img1_1.png'), 'w') as f:
-            f.write('text')
-        with open(os.path.join(dir, 'img1_2.png'), 'w') as f:
-            f.write('text2')
-        with open(os.path.join(dir, 'img2.png'), 'w') as f:
-            f.write('text3')
+    with open(os.path.join(func_dir, 'img1_1.png'), 'w') as f:
+        f.write('text')
+    with open(os.path.join(func_dir, 'img1_2.png'), 'w') as f:
+        f.write('text2')
+    with open(os.path.join(func_dir, 'img2.png'), 'w') as f:
+        f.write('text3')
 
-        test_data = [
-            {
-                'iteration': 1000,
-                'epoch': 1,
-                'images': OrderedDict([
-                    ('0', 'img1_1.png'),
-                    ('1', 'img1_2.png'),
-                ])
-            },
-            {
-                'iteration': 2000,
-                'epoch': 2,
-                'custom': 'test',
-                'images': OrderedDict([
-                    ('seg', 'img2.png'),
-                ])
-            }
-        ]
-        with open(info_path, 'w') as f:
-            json.dump(test_data, f)
-
-        self._dir = dir
-        self._info_path = info_path
-
-    def tearDown(self):
-        if os.path.exists(self._dir):
-            shutil.rmtree(self._dir)
-        db.session.remove()
-        db.remove_db()
-
-    def _get_dummy_result(self):
-        r = Result(path_name=self._dir)
-        r.id = 0
-        return r
-
-    def test_collect_images_no_meta(self):
-        os.remove(self._info_path)
-        result = self._get_dummy_result()
-
-        actual_list = collect_images.collect_images(result, [])
-        assert len(actual_list) == 0
-
-    def test_collect_images(self):
-        result = self._get_dummy_result()
-        actual_list = collect_images.collect_images(result, [])
-
-        assert len(actual_list) == 2
-        actual_img1 = actual_list[0]
-        assert len(actual_img1.content_list) == 2
-        assert actual_img1.content_list[0].name == 'img1_1.png'
-        assert actual_img1.content_list[0].tag == '0'
-        assert actual_img1.content_list[0].content == b'text'
-        assert actual_img1.content_list[1].name == 'img1_2.png'
-        assert actual_img1.content_list[1].tag == '1'
-        assert actual_img1.content_list[1].content == b'text2'
-        actual_img1_summary = json.loads(actual_img1.summary)
-        assert 'iteration' in actual_img1_summary
-        assert actual_img1_summary['iteration'] == 1000
-        assert 'epoch' in actual_img1_summary
-        assert actual_img1_summary['epoch'] == 1
-
-        actual_img2 = actual_list[1]
-        actual_img2_summary = json.loads(actual_img2.summary)
-        assert 'images' not in actual_img2_summary
-        assert 'custom' in actual_img2_summary
-        assert actual_img2_summary['custom'] == 'test'
-        assert len(actual_img2.content_list) == 1
-        assert actual_img2.content_list[0].name == 'img2.png'
-        assert actual_img2.content_list[0].tag == 'seg'
-        assert actual_img2.content_list[0].content == b'text3'
-
-    def test_collect_images_no_updated(self):
-        result = self._get_dummy_result()
-        first_assets = collect_images.collect_images(result, [])
-        assert len(first_assets) == 2
-
-        second_assets = collect_images.collect_images(
-            result, first_assets)
-        assert first_assets == second_assets
-
-    def test_collect_images_updated(self):
-        result = self._get_dummy_result()
-        first_assets = collect_images.collect_images(result, [])
-        assert len(first_assets) == 2
-
-        with open(os.path.join(self._dir, 'img1_3.png'), 'w') as f:
-            f.write('text add')
-        test_data2 = {
-            'iteration': 3000,
-            'epoch': 3,
-            'images': {
-                '0': 'img1_3.png',
-            }
+    test_data = [
+        {
+            'iteration': 1000,
+            'epoch': 1,
+            'images': OrderedDict([
+                ('0', 'img1_1.png'),
+                ('1', 'img1_2.png'),
+            ])
+        },
+        {
+            'iteration': 2000,
+            'epoch': 2,
+            'custom': 'test',
+            'images': OrderedDict([
+                ('seg', 'img2.png'),
+            ])
         }
-        with open(self._info_path, 'r') as f:
-            meta = json.load(f)
-        meta.append(test_data2)
-        with open(self._info_path, 'w') as f:
-            json.dump(meta, f)
+    ]
+    with open(info_path, 'w') as f:
+        json.dump(test_data, f)
 
-        second_assets = collect_images.collect_images(
-            result, first_assets)
-        assert len(second_assets) == 3
+    yield(func_dir)
 
-        actual_img3 = second_assets[2]
-        assert len(actual_img3.content_list) == 1
-        assert actual_img3.content_list[0].name == 'img1_3.png'
-        assert actual_img3.content_list[0].tag == '0'
-        assert actual_img3.content_list[0].content == b'text add'
-        actual_img3_summary = json.loads(actual_img3.summary)
-        assert 'iteration' in actual_img3_summary
-        assert actual_img3_summary['iteration'] == 3000
-        assert 'epoch' in actual_img3_summary
-        assert actual_img3_summary['epoch'] == 3
+    db.session.remove()
+    db.remove_db()
 
-    def test_collect_images_new_meta(self):
-        result = self._get_dummy_result()
-        first_assets = collect_images.collect_images(result, [])
-        assert len(first_assets) == 2
 
-        test_data = [
-            {
-                'iteration': 1001,
-                'epoch': 1,
-                'images': OrderedDict([
-                    ('0', 'img1_1.png'),
-                    ('1', 'img1_2.png'),
-                ])
-            }
-        ]
-        with open(self._info_path, 'w') as f:
-            json.dump(test_data, f)
-        second_assets = collect_images.collect_images(
-            result, first_assets)
-        assert len(second_assets) == 1
-        actual_img1 = second_assets[0]
-        assert len(actual_img1.content_list) == 2
-        assert actual_img1.content_list[0].name == 'img1_1.png'
-        assert actual_img1.content_list[0].tag == '0'
-        assert actual_img1.content_list[0].content == b'text'
-        assert actual_img1.content_list[1].name == 'img1_2.png'
-        assert actual_img1.content_list[1].tag == '1'
-        assert actual_img1.content_list[1].content == b'text2'
-        actual_img1_summary = json.loads(actual_img1.summary)
-        assert 'iteration' in actual_img1_summary
-        assert actual_img1_summary['iteration'] == 1001
-        assert 'epoch' in actual_img1_summary
-        assert actual_img1_summary['epoch'] == 1
+def _get_dummy_result(path):
+    r = Result(path_name=path)
+    r.id = 0
+    return r
+
+
+def test_collect_images_no_meta(result_path):
+    os.remove(os.path.join(result_path, '.chainerui_images'))
+    result = _get_dummy_result(result_path)
+
+    actual_list = collect_images.collect_images(result, [])
+    assert len(actual_list) == 0
+
+
+def test_collect_images(result_path):
+    result = _get_dummy_result(result_path)
+    actual_list = collect_images.collect_images(result, [])
+
+    assert len(actual_list) == 2
+    actual_img1 = actual_list[0]
+    assert len(actual_img1.content_list) == 2
+    assert actual_img1.content_list[0].name == 'img1_1.png'
+    assert actual_img1.content_list[0].tag == '0'
+    assert actual_img1.content_list[0].content == b'text'
+    assert actual_img1.content_list[1].name == 'img1_2.png'
+    assert actual_img1.content_list[1].tag == '1'
+    assert actual_img1.content_list[1].content == b'text2'
+    actual_img1_summary = json.loads(actual_img1.summary)
+    assert 'iteration' in actual_img1_summary
+    assert actual_img1_summary['iteration'] == 1000
+    assert 'epoch' in actual_img1_summary
+    assert actual_img1_summary['epoch'] == 1
+
+    actual_img2 = actual_list[1]
+    actual_img2_summary = json.loads(actual_img2.summary)
+    assert 'images' not in actual_img2_summary
+    assert 'custom' in actual_img2_summary
+    assert actual_img2_summary['custom'] == 'test'
+    assert len(actual_img2.content_list) == 1
+    assert actual_img2.content_list[0].name == 'img2.png'
+    assert actual_img2.content_list[0].tag == 'seg'
+    assert actual_img2.content_list[0].content == b'text3'
+
+
+def test_collect_images_no_updated(result_path):
+    result = _get_dummy_result(result_path)
+    first_assets = collect_images.collect_images(result, [])
+    assert len(first_assets) == 2
+
+    second_assets = collect_images.collect_images(result, first_assets)
+    assert first_assets == second_assets
+
+
+def test_collect_images_updated(result_path):
+    info_path = os.path.join(result_path, '.chainerui_images')
+    result = _get_dummy_result(result_path)
+    first_assets = collect_images.collect_images(result, [])
+    assert len(first_assets) == 2
+
+    with open(os.path.join(result_path, 'img1_3.png'), 'w') as f:
+        f.write('text add')
+    test_data2 = {
+        'iteration': 3000,
+        'epoch': 3,
+        'images': {
+            '0': 'img1_3.png',
+        }
+    }
+    with open(info_path, 'r') as f:
+        meta = json.load(f)
+    meta.append(test_data2)
+    with open(info_path, 'w') as f:
+        json.dump(meta, f)
+
+    second_assets = collect_images.collect_images(result, first_assets)
+    assert len(second_assets) == 3
+
+    actual_img3 = second_assets[2]
+    assert len(actual_img3.content_list) == 1
+    assert actual_img3.content_list[0].name == 'img1_3.png'
+    assert actual_img3.content_list[0].tag == '0'
+    assert actual_img3.content_list[0].content == b'text add'
+    actual_img3_summary = json.loads(actual_img3.summary)
+    assert 'iteration' in actual_img3_summary
+    assert actual_img3_summary['iteration'] == 3000
+    assert 'epoch' in actual_img3_summary
+    assert actual_img3_summary['epoch'] == 3
+
+
+def test_collect_images_new_meta(result_path):
+    info_path = os.path.join(result_path, '.chainerui_images')
+    result = _get_dummy_result(result_path)
+    first_assets = collect_images.collect_images(result, [])
+    assert len(first_assets) == 2
+
+    test_data = [
+        {
+            'iteration': 1001,
+            'epoch': 1,
+            'images': OrderedDict([
+                ('0', 'img1_1.png'),
+                ('1', 'img1_2.png'),
+            ])
+        }
+    ]
+    with open(info_path, 'w') as f:
+        json.dump(test_data, f)
+    second_assets = collect_images.collect_images(result, first_assets)
+    assert len(second_assets) == 1
+    actual_img1 = second_assets[0]
+    assert len(actual_img1.content_list) == 2
+    assert actual_img1.content_list[0].name == 'img1_1.png'
+    assert actual_img1.content_list[0].tag == '0'
+    assert actual_img1.content_list[0].content == b'text'
+    assert actual_img1.content_list[1].name == 'img1_2.png'
+    assert actual_img1.content_list[1].tag == '1'
+    assert actual_img1.content_list[1].content == b'text2'
+    actual_img1_summary = json.loads(actual_img1.summary)
+    assert 'iteration' in actual_img1_summary
+    assert actual_img1_summary['iteration'] == 1001
+    assert 'epoch' in actual_img1_summary
+    assert actual_img1_summary['epoch'] == 1

--- a/tests/tasks_tests/test_collect_images.py
+++ b/tests/tasks_tests/test_collect_images.py
@@ -4,28 +4,12 @@ import os
 
 import pytest
 
-from chainerui import CHAINERUI_ENV
-from chainerui import db
 from chainerui.models.result import Result
 from chainerui.tasks import collect_images
-from tests.helpers import NotInTestEnvironmentException
-
-
-@pytest.fixture(autouse=True, scope='module')
-def temp_db():
-    if not CHAINERUI_ENV == 'test':
-        raise NotInTestEnvironmentException(
-            'set environment variable CHAINERUI_ENV=test '
-            'when you run this test'
-        )
-    db.init_db()
 
 
 @pytest.fixture(autouse=True, scope='function')
-def result_path(func_dir):
-    db.setup(test_mode=True)
-    db.upgrade()
-
+def result_path(func_dir, func_db):
     info_path = os.path.join(func_dir, '.chainerui_images')
 
     with open(os.path.join(func_dir, 'img1_1.png'), 'w') as f:
@@ -56,10 +40,7 @@ def result_path(func_dir):
     with open(info_path, 'w') as f:
         json.dump(test_data, f)
 
-    yield(func_dir)
-
-    db.session.remove()
-    db.remove_db()
+    return func_dir
 
 
 def _get_dummy_result(path):

--- a/tests/tasks_tests/test_crawl_result.py
+++ b/tests/tasks_tests/test_crawl_result.py
@@ -1,88 +1,82 @@
 import datetime
 import json
 import os
-import shutil
-import tempfile
-import unittest
+
+import pytest
 
 from chainerui.models.result import Result
 from chainerui.tasks.crawl_result import _check_log_updated
 from chainerui.tasks.crawl_result import load_result_json
 
 
-class TestCrawlResult(unittest.TestCase):
+@pytest.fixture(autouse=True, scope='function')
+def result_path(func_dir):
+    path = func_dir
+    log = [
+        {
+            "main/loss": 0.1933198869228363,
+            "validation/main/loss": 0.09147150814533234,
+            "iteration": 600,
+            "elapsed_time": 16.052587032318115,
+            "epoch": 1,
+            "main/accuracy": 0.9421835541725159,
+            "validation/main/accuracy": 0.9703000783920288
+        },
+        {
+            "main/loss": 0.07222291827201843,
+            "validation/main/loss": 0.08141259849071503,
+            "iteration": 1200,
+            "elapsed_time": 19.54666304588318,
+            "epoch": 2,
+            "main/accuracy": 0.9771820902824402,
+            "validation/main/accuracy": 0.975399911403656
+        }
+    ]
+    with open(os.path.join(path, 'log'), 'w') as f:
+        json.dump(log, f)
 
-    def setUp(self):
-        test_dir = tempfile.mkdtemp(prefix='chainerui_test_crawl_result')
-        self._dir = test_dir
+    with open(os.path.join(path, 'log.txt'), 'w') as f:
+        f.write('json')
 
-        path = os.path.join(test_dir, 'result')
-        self._result_path = path
-        os.makedirs(path)
-        log = [
-            {
-                "main/loss": 0.1933198869228363,
-                "validation/main/loss": 0.09147150814533234,
-                "iteration": 600,
-                "elapsed_time": 16.052587032318115,
-                "epoch": 1,
-                "main/accuracy": 0.9421835541725159,
-                "validation/main/accuracy": 0.9703000783920288
-            },
-            {
-                "main/loss": 0.07222291827201843,
-                "validation/main/loss": 0.08141259849071503,
-                "iteration": 1200,
-                "elapsed_time": 19.54666304588318,
-                "epoch": 2,
-                "main/accuracy": 0.9771820902824402,
-                "validation/main/accuracy": 0.975399911403656
-            }
-        ]
-        with open(os.path.join(path, 'log'), 'w') as f:
-            json.dump(log, f)
+    return path
 
-        with open(os.path.join(path, 'log.txt'), 'w') as f:
-            f.write('json')
 
-    def tearDown(self):
-        if os.path.exists(self._dir):
-            shutil.rmtree(self._dir)
+def test_check_log_updated(result_path):
+    result = Result(path_name=result_path)
+    assert _check_log_updated(result)
+    assert result.log_modified_at is not None
+    # NOTE: getmtime precision is rough, so back 0.1s on purpose
+    modified_at = result.log_modified_at - datetime.timedelta(
+        milliseconds=100)
+    result.log_modified_at = modified_at
 
-    def test_check_log_updated(self):
-        result = Result(path_name=self._result_path)
-        assert _check_log_updated(result)
-        assert result.log_modified_at is not None
-        # NOTE: getmtime precision is rough, so back 0.1s on purpose
-        modified_at = result.log_modified_at - datetime.timedelta(
-            milliseconds=100)
-        result.log_modified_at = modified_at
+    with open(os.path.join(result_path, 'log'), 'r') as f:
+        logs = json.load(f)
+    logs.append({
+        "main/loss": 0.04882155358791351,
+        "validation/main/loss": 0.09093106538057327,
+        "iteration": 1800,
+        "elapsed_time": 23.046298027038574,
+        "epoch": 3,
+        "main/accuracy": 0.9839146733283997,
+        "validation/main/accuracy": 0.9726001620292664
+    })
+    with open(os.path.join(result_path, 'log'), 'w') as f:
+        json.dump(logs, f)
+    assert _check_log_updated(result)
+    assert result.log_modified_at != modified_at
+    modified_at = result.log_modified_at
 
-        with open(os.path.join(self._result_path, 'log'), 'r') as f:
-            logs = json.load(f)
-        logs.append({
-            "main/loss": 0.04882155358791351,
-            "validation/main/loss": 0.09093106538057327,
-            "iteration": 1800,
-            "elapsed_time": 23.046298027038574,
-            "epoch": 3,
-            "main/accuracy": 0.9839146733283997,
-            "validation/main/accuracy": 0.9726001620292664
-        })
-        with open(os.path.join(self._result_path, 'log'), 'w') as f:
-            json.dump(logs, f)
-        assert _check_log_updated(result)
-        assert result.log_modified_at != modified_at
-        modified_at = result.log_modified_at
+    assert not _check_log_updated(result)
+    assert result.log_modified_at == modified_at
 
-        assert not _check_log_updated(result)
-        assert result.log_modified_at == modified_at
+    os.remove(os.path.join(result_path, 'log'))
+    assert not _check_log_updated(result)
 
-        os.remove(os.path.join(self._result_path, 'log'))
-        assert not _check_log_updated(result)
 
-    def test_load_result_json_with_correct_file(self):
-        assert len(load_result_json(self._result_path, 'log')) > 0
+def test_load_result_json_with_correct_file(result_path):
+    assert len(load_result_json(result_path, 'log')) > 0
 
-    def test_load_result_json_with_incorrect_file(self):
-        assert len(load_result_json(self._result_path, 'log.txt')) == 0
+
+def test_load_result_json_with_incorrect_file(result_path):
+    assert len(load_result_json(result_path, 'log.txt')) == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,7 @@
 import json
 import os
-import shutil
-import tempfile
-import unittest
 
+import pytest
 from six import string_types
 
 from chainerui import CHAINERUI_ENV
@@ -15,7 +13,7 @@ from tests.helpers import assert_json_api
 from tests.helpers import NotInTestEnvironmentException
 
 
-def setup_test_project(root_path):
+def _setup_test_project(root_path):
     # log only
     path = os.path.join(root_path, '10000')
     os.makedirs(path)
@@ -138,470 +136,478 @@ def setup_test_project(root_path):
     open(os.path.join(path, 'snapshot_iter_2400'), 'w').close()
 
 
-def setup_test_db(project_path, project_name):
+def _setup_test_db(project_path, project_name):
     db.upgrade()
 
     # insert test data
     Project.create(project_path, project_name)
 
 
-class TestAPI(unittest.TestCase):
+@pytest.fixture(autouse=True, scope='module')
+def temp_db():
+    if not CHAINERUI_ENV == 'test':
+        raise NotInTestEnvironmentException(
+            'set environment variable CHAINERUI_ENV=test '
+            'when you run this test'
+        )
+    db.init_db()
 
-    @classmethod
-    def setUpClass(cls):
-        if not CHAINERUI_ENV == 'test':
-            raise NotInTestEnvironmentException(
-                'set environment variable CHAINERUI_ENV=test '
-                'when you run this test'
-            )
-        db.init_db()
 
-        test_dir = tempfile.mkdtemp(prefix='chainerui_test_api')
-        cls._dir = test_dir
-        project_path = os.path.join(test_dir, 'test_project')
-        setup_test_project(project_path)
-        cls._project_path = project_path
+@pytest.fixture(autouse=True, scope='function')
+def project(func_dir):
+    db.setup(test_mode=True)
+    db.upgrade()
 
-    @classmethod
-    def tearDownClass(cls):
-        if os.path.exists(cls._dir):
-            shutil.rmtree(cls._dir)
+    project_path = os.path.join(func_dir, 'test_project')
+    _setup_test_project(project_path)
+    project_name = 'my-project'
+    Project.create(project_path, project_name)
 
-    def setUp(self):
-        db.setup(test_mode=True)
+    yield(project_path, project_name)
 
-        project_name = 'my-project'
-        setup_test_db(self._project_path, project_name)
-        self._project_name = project_name
+    db.session.remove()
+    db.remove_db()
 
-        app = create_app()
-        app.testing = True
-        self.app = app.test_client()
 
-    def tearDown(self):
-        db.session.remove()
-        db.remove_db()
+@pytest.fixture(autouse=True, scope='function')
+def app(func_dir):
+    app = create_app()
+    app.testing = True
+    return app.test_client()
 
-    def assert_test_project(self, project, path=None, name=None):
-        assert len(project) == 3
-        assert project['pathName'] == self._project_path if \
-            path is None else path
-        assert project['name'] == self._project_name if name is None else name
-        assert isinstance(project['id'], int)
 
-    def assert_test_project_result(self, result, name=None, logs_limit=None):
-        assert len(result) == 9
-        assert isinstance(result['commands'], list)
-        self.assert_test_logs(result['logs'], logs_limit)
-        assert isinstance(result['args'], list)
-        assert isinstance(result['snapshots'], list)
-        assert isinstance(result['isUnregistered'], bool)
-        assert isinstance(result['id'], int)
-        assert result['pathName'].startswith(self._project_path)
-        assert result['name'] == name
+def _assert_test_project(project, path, name):
+    assert len(project) == 3
+    assert project['pathName'] == path
+    assert project['name'] == name
+    assert isinstance(project['id'], int)
 
-    def assert_test_logs(self, logs, logs_limit=None):
-        assert isinstance(logs, list)
-        assert logs_limit is None or logs_limit == -1 \
-            or len(logs) == min(7, logs_limit)
 
-    # GET /api/v1/projects
-    def test_get_project_list(self):
-        resp = self.app.get('/api/v1/projects')
-        data = assert_json_api(resp)
-        assert len(data) == 1
-        assert isinstance(data['projects'], list)
-        self.assert_test_project(data['projects'][0])
+def _assert_test_project_result(result, path, name, logs_limit=None):
+    assert len(result) == 9
+    assert isinstance(result['commands'], list)
+    _assert_test_logs(result['logs'], logs_limit)
+    assert isinstance(result['args'], list)
+    assert isinstance(result['snapshots'], list)
+    assert isinstance(result['isUnregistered'], bool)
+    assert isinstance(result['id'], int)
+    assert result['pathName'].startswith(path)
+    assert result['name'] == name
 
-    # GET /api/v1/projects/<int:id>
-    def test_get_project(self):
-        resp = self.app.get('/api/v1/projects/1')
-        data = assert_json_api(resp)
-        assert len(data) == 1
-        self.assert_test_project(data['project'])
 
-        resp = self.app.get('/api/v1/projects/12345')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['project'] is None
+def _assert_test_logs(logs, logs_limit=None):
+    assert isinstance(logs, list)
+    assert logs_limit is None or logs_limit == -1 or len(logs) == min(
+        7, logs_limit)
 
-    # POST /api/v1/projects
-    def test_post_project(self):
-        temp_dir = os.path.join(self._dir, 'test_post_project')
-        os.mkdir(temp_dir)
 
-        # success
-        request_json = {'project': {'path_name': temp_dir}}
-        resp = self.app.post(
-            '/api/v1/projects', data=json.dumps(request_json),
-            content_type='application/json')
-        data = assert_json_api(resp)
-        assert len(data) == 1
-        self.assert_test_project(data['project'], path=temp_dir, name=temp_dir)
+# GET /api/v1/projects
+def test_get_project_list(project, app):
+    path, name = project
+    resp = app.get('/api/v1/projects')
+    data = assert_json_api(resp)
+    assert len(data) == 1
+    assert isinstance(data['projects'], list)
+    _assert_test_project(data['projects'][0], path, name)
 
-        # fail, required param is lack
-        request_json = {'project': {'name': 'name'}}
-        resp = self.app.post(
-            '/api/v1/projects', data=json.dumps(request_json),
-            content_type='application/json')
-        data = assert_json_api(resp, 400)
-        assert len(data) == 2
 
-        # fail, the path is duplicated
-        request_json = {'project': {'path_name': self._project_path}}
-        resp = self.app.post(
-            '/api/v1/projects', data=json.dumps(request_json),
-            content_type='application/json')
-        data = assert_json_api(resp, 400)
-        assert len(data) == 2
+# GET /api/v1/projects/<int:id>
+def test_get_project(project, app):
+    resp = app.get('/api/v1/projects/1')
+    data = assert_json_api(resp)
+    assert len(data) == 1
+    _assert_test_project(data['project'], *project)
 
-    # PUT /api/v1/projects/<int:id>
-    def test_put_project(self):
-        request_json = {
-            'project': {
-                'id': 1,
-                'name': 'new-name',
-            }
+    resp = app.get('/api/v1/projects/12345')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['project'] is None
+
+
+# POST /api/v1/projects
+def test_post_project(func_dir, project, app):
+    temp_dir = os.path.join(func_dir, 'test_post_project')
+    os.mkdir(temp_dir)
+
+    # success
+    request_json = {'project': {'path_name': temp_dir}}
+    resp = app.post(
+        '/api/v1/projects', data=json.dumps(request_json),
+        content_type='application/json')
+    data = assert_json_api(resp)
+    assert len(data) == 1
+    _assert_test_project(data['project'], temp_dir, temp_dir)
+
+    # fail, required param is lack
+    request_json = {'project': {'name': 'name'}}
+    resp = app.post(
+        '/api/v1/projects', data=json.dumps(request_json),
+        content_type='application/json')
+    data = assert_json_api(resp, 400)
+    assert len(data) == 2
+
+    # fail, the path is duplicated
+    request_json = {'project': {'path_name': project[0]}}
+    resp = app.post(
+        '/api/v1/projects', data=json.dumps(request_json),
+        content_type='application/json')
+    data = assert_json_api(resp, 400)
+    assert len(data) == 2
+
+
+# PUT /api/v1/projects/<int:id>
+def test_put_project(project, app):
+    request_json = {
+        'project': {
+            'id': 1,
+            'name': 'new-name',
         }
+    }
 
-        resp = self.app.put(
-            '/api/v1/projects/1',
-            data=json.dumps(request_json),
-            content_type='application/json')
+    resp = app.put(
+        '/api/v1/projects/1', data=json.dumps(request_json),
+        content_type='application/json')
+    data = assert_json_api(resp)
+    assert len(data) == 1
+    _assert_test_project(
+        data['project'], project[0], name=request_json['project']['name'])
+
+    resp = app.put('/api/v1/projects/12345')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['project'] is None
+
+
+# DELETE /api/v1/projects/<int:id>
+def test_delete_project(project, app):
+    resp = app.delete('/api/v1/projects/1')
+    data = assert_json_api(resp)
+    assert len(data) == 1
+    _assert_test_project(data['project'], *project)
+
+    resp = app.delete('/api/v1/projects/12345')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['projects'] is None  # TODO(ofk): Is projects key correct?
+
+
+# GET /api/v1/projects/<int:project_id>/results
+def test_get_result_list(project, app):
+    for logs_limit in [None, -1, 0, 5, 7, 100]:
+        url = '/api/v1/projects/1/results'
+        if logs_limit is not None:
+            url += '?logs_limit=' + str(logs_limit)
+
+        resp = app.get(url)
         data = assert_json_api(resp)
         assert len(data) == 1
-        self.assert_test_project(
-            data['project'], name=request_json['project']['name'])
+        assert len(data['results']) >= 3
+        for i in range(3):
+            _assert_test_project_result(
+                data['results'][i], project[0], None, logs_limit=logs_limit)
 
-        resp = self.app.put('/api/v1/projects/12345')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['project'] is None
+    # raise an unexpected exception when GET /api/v1/projects/12345/results
 
-    # DELETE /api/v1/projects/<int:id>
-    def test_delete_project(self):
-        resp = self.app.delete('/api/v1/projects/1')
-        data = assert_json_api(resp)
-        assert len(data) == 1
-        self.assert_test_project(data['project'])
 
-        resp = self.app.delete('/api/v1/projects/12345')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['projects'] is None  # TODO(ofk): Is projects key correct?
-
-    # GET /api/v1/projects/<int:project_id>/results
-    def test_get_result_list(self):
-        for logs_limit in [None, -1, 0, 5, 7, 100]:
-            url = '/api/v1/projects/1/results'
+# GET /api/v1/projects/<int:project_id>/results/<int:id>
+def test_get_result(project, app):
+    for logs_limit in [None, -1, 0, 5, 7, 100]:
+        for i in range(3):
+            url = '/api/v1/projects/1/results/' + str(i + 1)
             if logs_limit is not None:
                 url += '?logs_limit=' + str(logs_limit)
 
-            resp = self.app.get(url)
+            resp = app.get(url)
             data = assert_json_api(resp)
             assert len(data) == 1
-            assert len(data['results']) >= 3
-            for i in range(3):
-                self.assert_test_project_result(
-                    data['results'][i], logs_limit=logs_limit)
+            _assert_test_project_result(
+                data['result'], project[0], None, logs_limit=logs_limit)
+            assert data['result']['id'] == i + 1
 
-        # raise an unexpected exception when GET /api/v1/projects/12345/results
+    # invalid project ID
+    resp = app.get('/api/v1/projects/12345/results/1')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['project'] is None
 
-    # GET /api/v1/projects/<int:project_id>/results/<int:id>
-    def test_get_result(self):
-        for logs_limit in [None, -1, 0, 5, 7, 100]:
-            for i in range(3):
-                url = '/api/v1/projects/1/results/' + str(i + 1)
-                if logs_limit is not None:
-                    url += '?logs_limit=' + str(logs_limit)
+    # invalid result ID
+    resp = app.get('/api/v1/projects/1/results/12345')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['result'] is None
 
-                resp = self.app.get(url)
-                data = assert_json_api(resp)
-                assert len(data) == 1
-                self.assert_test_project_result(
-                    data['result'], logs_limit=logs_limit)
-                assert data['result']['id'] == i + 1
 
-        # invalid project ID
-        resp = self.app.get('/api/v1/projects/12345/results/1')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['project'] is None
-
-        # invalid result ID
-        resp = self.app.get('/api/v1/projects/1/results/12345')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['result'] is None
-
-    # PUT /api/v1/projects/<int:project_id>/results/<int:id>
-    def test_put_result(self):
-        request_jsons = [
-            {
-                'result': {
-                    'id': 1,
-                    'name': 'new-name1',
-                }
-            },
-            {
-                'result': {
-                    'id': 2,
-                    'name': 'new-name2',
-                    'isUnregistered': True,
-                }
-            },
-            {
-                'result': {
-                    'id': 3,
-                    'name': 'new-name3',
-                    'isUnregistered': False,
-                }
-            },
-        ]
-
-        for i in range(3):
-            resp = self.app.put(
-                '/api/v1/projects/1/results/' + str(i + 1),
-                data=json.dumps(request_jsons[i]),
-                content_type='application/json')
-            data = assert_json_api(resp)
-            assert len(data) == 1
-            self.assert_test_project_result(
-                data['result'], request_jsons[i]['result']['name'])
-
-        resp = self.app.put('/api/v1/projects/1/results/12345')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['result'] is None
-
-        # not raise an exception when PUT /api/v1/projects/12345/results/1
-
-    # DELETE /api/v1/projects/<int:project_id>/results/<int:id>
-    def test_delete_result(self):
-        for i in range(3):
-            resp = self.app.delete('/api/v1/projects/1/results/' + str(i + 1))
-            data = assert_json_api(resp)
-            assert len(data) == 1
-            self.assert_test_project_result(data['result'])
-
-        resp = self.app.delete('/api/v1/projects/1/results/12345')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['result'] is None
-
-        # not raise an exception when DELETE /api/v1/projects/12345/results/1
-
-    # POST /api/v1/projects/<int:project_id>/results/<int:result_id>/commands,
-    def test_post_result_command(self):
-        project2_path = os.path.join(self._dir, 'test_project2')
-        result_path = os.path.join(project2_path, '10003')
-        os.makedirs(result_path)
-        with open(os.path.join(result_path, 'log'), 'w') as f:
-            json.dump([], f)
-        Project.create(project2_path, 'command-test-project')
-
-        request_jsons = [
-            {
-                'name': 'adjust_hyperparams',
-                'body': {
-                    'alpha': 0.0007,
-                    'beta1': 0.8,
-                    'beat2': 1.0,
-                },
-                'schedule': {
-                    'value': 4,
-                    'key': 'epoch',
-                },
-                'resultId': 1,
-            },
-            {
-                'name': 'adjust_hyperparams',
-                'body': None,
-                'schedule': None,
-                'resultId': 2,
-            },
-            {
-                'name': 'take_snapshot',
-                'schedule': {
-                    'value': 4800,
-                    'key': 'iteration',
-                },
-                'resultId': 3,
-            },
-        ]
-
-        # not set extension
-        resp = self.app.post(
-            '/api/v1/projects/2/results/4/commands',
-            data=json.dumps(request_jsons[0]),
-            content_type='application/json')
-        data = assert_json_api(resp, 400)
-        assert len(data) == 1
-        assert isinstance(data['message'], string_types)
-        assert 'not set' in data['message']
-
-        # job run on v0.1.0 so .chainerui_commands is not created
-        with open(os.path.join(result_path, 'commands'), 'w') as f:
-            json.dump([], f)
-        resp = self.app.post(
-            '/api/v1/projects/2/results/4/commands',
-            data=json.dumps(request_jsons[0]),
-            content_type='application/json')
-        data = assert_json_api(resp, 400)
-        assert len(data) == 1
-        assert isinstance(data['message'], string_types)
-        assert 'stopped' in data['message']
-
-        # extension is set up but not run
-        os.remove(os.path.join(result_path, '.chainerui_commands'))
-        CommandsState._dump(result_path, CommandsState._load(
-            result_path, initialize=True))
-        resp = self.app.post(
-            '/api/v1/projects/2/results/4/commands',
-            data=json.dumps(request_jsons[0]),
-            content_type='application/json')
-        data = assert_json_api(resp, 400)
-        assert len(data) == 1
-        assert isinstance(data['message'], string_types)
-        assert 'not run' in data['message']
-
-        # job has already started
-        CommandsState.run(result_path)
-        for i in range(3):
-            resp = self.app.post(
-                '/api/v1/projects/2/results/4/commands',
-                data=json.dumps(request_jsons[i]),
-                content_type='application/json')
-            data = assert_json_api(resp)
-            assert len(data) == 1
-            assert len(data['commands']) > 0
-            command = data['commands'][0]
-            assert isinstance(command['id'], int)
-            assert isinstance(command['name'], string_types)
-            assert len(command['request']) == 4
-            assert command['request']['schedule'] is None or isinstance(
-                command['request']['schedule'], dict)
-            assert command['request']['body'] is None or isinstance(
-                command['request']['body'], dict)
-            assert isinstance(command['request']['created_at'], string_types)
-            assert isinstance(command['request']['status'], string_types)
-            assert 'response' in command
-
-        # job has stopped
-        CommandsState.stop(result_path)
-        resp = self.app.post(
-            '/api/v1/projects/2/results/4/commands',
-            data=json.dumps(request_jsons[0]),
-            content_type='application/json')
-        data = assert_json_api(resp, 400)
-        assert len(data) == 1
-        assert isinstance(data['message'], string_types)
-        assert 'stopped' in data['message']
-
-        request_jsons = [
-            {
-                'name': 'invalid_schedule',
-                'schedule': {
-                    'value': None,
-                    'key': 'epoch',
-                },
-                'resultId': 1,
-            },
-            {
-                'name': None,
-                'resultId': 2,
-            },
-        ]
-
-        for i in range(2):
-            resp = self.app.post(
-                '/api/v1/projects/2/results/4/commands',
-                data=json.dumps(request_jsons[i]),
-                content_type='application/json')
-            data = assert_json_api(resp, 400)
-            assert len(data) == 1
-            assert isinstance(data['message'], string_types)
-
-        resp = self.app.post('/api/v1/projects/2/results/4/commands')
-        data = assert_json_api(resp, 400)
-        assert len(data) == 1
-        assert isinstance(data['message'], string_types)
-
-        resp = self.app.post('/api/v1/projects/2/results/12345/commands')
-        data = assert_json_api(resp, 404)
-        assert isinstance(data['message'], string_types)
-        assert data['result'] is None
-
-        # not raise an exception
-        #   when PUT /api/v1/projects/12345/results/4/commands
-
-    # GET /api/v1/projects/<int:project_id>/results/<int:id>/assets
-    def test_get_assets(self):
-        project3_path = os.path.join(self._dir, 'test_project3')
-        path = os.path.join(project3_path, '10004')
-        os.makedirs(path)
-        image_info = [
-            {
-                "epoch": 1,
-                "iteration": 600,
-                "images": {
-                    "train": "iter_600_61b3a8fa.png",
-                    "train_reconstructed": "iter_600_c15c042b.png",
-                }
+# PUT /api/v1/projects/<int:project_id>/results/<int:id>
+def test_put_result(project, app):
+    request_jsons = [
+        {
+            'result': {
+                'id': 1,
+                'name': 'new-name1',
             }
-        ]
-        with open(os.path.join(path, '.chainerui_images'), 'w') as f:
-            json.dump(image_info, f)
-        open(os.path.join(path, 'iter_600_61b3a8fa.png'), 'w') .close()
-        open(os.path.join(path, 'iter_600_c15c042b.png'), 'w') .close()
-        with open(os.path.join(path, 'log'), 'w') as f:
-            json.dump([], f)
-        Project.create(project3_path, 'assets-test-project')
+        },
+        {
+            'result': {
+                'id': 2,
+                'name': 'new-name2',
+                'isUnregistered': True,
+            }
+        },
+        {
+            'result': {
+                'id': 3,
+                'name': 'new-name3',
+                'isUnregistered': False,
+            }
+        },
+    ]
 
-        url = '/api/v1/projects/2/results/4/assets'
-        resp = self.app.get(url)
+    for i in range(3):
+        resp = app.put(
+            '/api/v1/projects/1/results/' + str(i + 1),
+            data=json.dumps(request_jsons[i]),
+            content_type='application/json')
         data = assert_json_api(resp)
-        assert 'assets' in data
-        assert len(data['assets']) == 1
-        assert 'contents' in data['assets'][0]
-        assert len(data['assets'][0]['contents']) == 2
-        assert 'train_info' in data['assets'][0]
+        assert len(data) == 1
+        _assert_test_project_result(
+            data['result'], project[0], request_jsons[i]['result']['name'])
 
-        # invalid project ID
-        resp = self.app.get('/api/v1/projects/12345/results/4/assets')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['project'] is None
+    resp = app.put('/api/v1/projects/1/results/12345')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['result'] is None
 
-        # invalid result ID
-        resp = self.app.get('/api/v1/projects/2/results/12345/assets')
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
-        assert isinstance(data['message'], string_types)
-        assert data['result'] is None
+    # not raise an exception when PUT /api/v1/projects/12345/results/1
 
-        # empty assets
-        resp = self.app.get('/api/v1/projects/1/results/1/assets')
+
+# DELETE /api/v1/projects/<int:project_id>/results/<int:id>
+def test_delete_result(project, app):
+    for i in range(3):
+        resp = app.delete('/api/v1/projects/1/results/' + str(i + 1))
         data = assert_json_api(resp)
-        assert 'assets' in data
-        assert len(data['assets']) == 0
+        assert len(data) == 1
+        _assert_test_project_result(data['result'], project[0], None)
 
-        # resource check
-        resource_url = url + '/1'
-        resp = self.app.get(resource_url)
-        assert resp.status_code == 200
+    resp = app.delete('/api/v1/projects/1/results/12345')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['result'] is None
 
-        resource_url = url + '/3'
-        resp = self.app.get(resource_url)
-        data = assert_json_api(resp, 404)
-        assert len(data) == 2
+    # not raise an exception when DELETE /api/v1/projects/12345/results/1
+
+
+# POST /api/v1/projects/<int:project_id>/results/<int:result_id>/commands,
+def test_post_result_command(func_dir, project, app):
+    project2_path = os.path.join(func_dir, 'test_project2')
+    result_path = os.path.join(project2_path, '10003')
+    os.makedirs(result_path)
+    with open(os.path.join(result_path, 'log'), 'w') as f:
+        json.dump([], f)
+    Project.create(project2_path, 'command-test-project')
+
+    request_jsons = [
+        {
+            'name': 'adjust_hyperparams',
+            'body': {
+                'alpha': 0.0007,
+                'beta1': 0.8,
+                'beat2': 1.0,
+            },
+            'schedule': {
+                'value': 4,
+                'key': 'epoch',
+            },
+            'resultId': 1,
+        },
+        {
+            'name': 'adjust_hyperparams',
+            'body': None,
+            'schedule': None,
+            'resultId': 2,
+        },
+        {
+            'name': 'take_snapshot',
+            'schedule': {
+                'value': 4800,
+                'key': 'iteration',
+            },
+            'resultId': 3,
+        },
+    ]
+
+    # not set extension
+    resp = app.post(
+        '/api/v1/projects/2/results/4/commands',
+        data=json.dumps(request_jsons[0]),
+        content_type='application/json')
+    data = assert_json_api(resp, 400)
+    assert len(data) == 1
+    assert isinstance(data['message'], string_types)
+    assert 'not set' in data['message']
+
+    # job run on v0.1.0 so .chainerui_commands is not created
+    with open(os.path.join(result_path, 'commands'), 'w') as f:
+        json.dump([], f)
+    resp = app.post(
+        '/api/v1/projects/2/results/4/commands',
+        data=json.dumps(request_jsons[0]),
+        content_type='application/json')
+    data = assert_json_api(resp, 400)
+    assert len(data) == 1
+    assert isinstance(data['message'], string_types)
+    assert 'stopped' in data['message']
+
+    # extension is set up but not run
+    os.remove(os.path.join(result_path, '.chainerui_commands'))
+    CommandsState._dump(result_path, CommandsState._load(
+        result_path, initialize=True))
+    resp = app.post(
+        '/api/v1/projects/2/results/4/commands',
+        data=json.dumps(request_jsons[0]),
+        content_type='application/json')
+    data = assert_json_api(resp, 400)
+    assert len(data) == 1
+    assert isinstance(data['message'], string_types)
+    assert 'not run' in data['message']
+
+    # job has already started
+    CommandsState.run(result_path)
+    for i in range(3):
+        resp = app.post(
+            '/api/v1/projects/2/results/4/commands',
+            data=json.dumps(request_jsons[i]),
+            content_type='application/json')
+        data = assert_json_api(resp)
+        assert len(data) == 1
+        assert len(data['commands']) > 0
+        command = data['commands'][0]
+        assert isinstance(command['id'], int)
+        assert isinstance(command['name'], string_types)
+        assert len(command['request']) == 4
+        assert command['request']['schedule'] is None or isinstance(
+            command['request']['schedule'], dict)
+        assert command['request']['body'] is None or isinstance(
+            command['request']['body'], dict)
+        assert isinstance(command['request']['created_at'], string_types)
+        assert isinstance(command['request']['status'], string_types)
+        assert 'response' in command
+
+    # job has stopped
+    CommandsState.stop(result_path)
+    resp = app.post(
+        '/api/v1/projects/2/results/4/commands',
+        data=json.dumps(request_jsons[0]),
+        content_type='application/json')
+    data = assert_json_api(resp, 400)
+    assert len(data) == 1
+    assert isinstance(data['message'], string_types)
+    assert 'stopped' in data['message']
+
+    request_jsons = [
+        {
+            'name': 'invalid_schedule',
+            'schedule': {
+                'value': None,
+                'key': 'epoch',
+            },
+            'resultId': 1,
+        },
+        {
+            'name': None,
+            'resultId': 2,
+        },
+    ]
+
+    for i in range(2):
+        resp = app.post(
+            '/api/v1/projects/2/results/4/commands',
+            data=json.dumps(request_jsons[i]),
+            content_type='application/json')
+        data = assert_json_api(resp, 400)
+        assert len(data) == 1
         assert isinstance(data['message'], string_types)
-        assert data['asset'] is None
+
+    resp = app.post('/api/v1/projects/2/results/4/commands')
+    data = assert_json_api(resp, 400)
+    assert len(data) == 1
+    assert isinstance(data['message'], string_types)
+
+    resp = app.post('/api/v1/projects/2/results/12345/commands')
+    data = assert_json_api(resp, 404)
+    assert isinstance(data['message'], string_types)
+    assert data['result'] is None
+
+    # not raise an exception
+    #   when PUT /api/v1/projects/12345/results/4/commands
+
+
+# GET /api/v1/projects/<int:project_id>/results/<int:id>/assets
+def test_get_assets(func_dir, project, app):
+    project3_path = os.path.join(func_dir, 'test_project3')
+    path = os.path.join(project3_path, '10004')
+    os.makedirs(path)
+    image_info = [
+        {
+            "epoch": 1,
+            "iteration": 600,
+            "images": {
+                "train": "iter_600_61b3a8fa.png",
+                "train_reconstructed": "iter_600_c15c042b.png",
+            }
+        }
+    ]
+    with open(os.path.join(path, '.chainerui_images'), 'w') as f:
+        json.dump(image_info, f)
+    open(os.path.join(path, 'iter_600_61b3a8fa.png'), 'w') .close()
+    open(os.path.join(path, 'iter_600_c15c042b.png'), 'w') .close()
+    with open(os.path.join(path, 'log'), 'w') as f:
+        json.dump([], f)
+    Project.create(project3_path, 'assets-test-project')
+
+    url = '/api/v1/projects/2/results/4/assets'
+    resp = app.get(url)
+    data = assert_json_api(resp)
+    assert 'assets' in data
+    assert len(data['assets']) == 1
+    assert 'contents' in data['assets'][0]
+    assert len(data['assets'][0]['contents']) == 2
+    assert 'train_info' in data['assets'][0]
+
+    # invalid project ID
+    resp = app.get('/api/v1/projects/12345/results/4/assets')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['project'] is None
+
+    # invalid result ID
+    resp = app.get('/api/v1/projects/2/results/12345/assets')
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['result'] is None
+
+    # empty assets
+    resp = app.get('/api/v1/projects/1/results/1/assets')
+    data = assert_json_api(resp)
+    assert 'assets' in data
+    assert len(data['assets']) == 0
+
+    # resource check
+    resource_url = url + '/1'
+    resp = app.get(resource_url)
+    assert resp.status_code == 200
+
+    resource_url = url + '/3'
+    resp = app.get(resource_url)
+    data = assert_json_api(resp, 404)
+    assert len(data) == 2
+    assert isinstance(data['message'], string_types)
+    assert data['asset'] is None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,11 +22,13 @@ def db_url(func_dir):
 
 def test_server_debug(db_url):
     args = app.create_parser().parse_args(
-        ['--db', db_url, 'server', '-H', 'test.domain', '-p', '5001', '-d'])
+        ['--db', db_url, '--db-echo', 'server', '-H', 'test.domain', '-p',
+         '5001', '-d'])
     assert args.host == 'test.domain'
     assert args.port == 5001
     assert args.debug
     assert args.db == db_url
+    assert args.db_echo
 
     mock_app = MagicMock()
     mock_app_creator = MagicMock(return_value=mock_app)
@@ -50,6 +52,7 @@ def test_server_production(db_url):
     assert args.port == 5001
     assert not args.debug
     assert args.db == db_url
+    assert not args.db_echo
 
     mock_app = MagicMock()
     mock_app_creator = MagicMock(return_value=mock_app)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,144 +1,138 @@
 from mock import MagicMock
 from mock import patch
 import os
-import shutil
-import tempfile
-import unittest
+
+import pytest
 
 from chainerui import app
 from chainerui import db
 from chainerui.models.project import Project
 
 
-class TestApp(unittest.TestCase):
+@pytest.fixture(autouse=True, scope='function')
+def db_url(func_dir):
+    db_path = os.path.join(func_dir, 'test_app.db')
+    db_url = 'sqlite:///' + db_path
+    yield(db_url)
 
-    def setUp(self):
-        temp_dir = tempfile.mkdtemp(prefix='chainerui_test_app_')
-        self._dir = temp_dir
-        self._db_path = os.path.join(temp_dir, 'test_app.db')
-        self._db_url = 'sqlite:///' + self._db_path
+    if db._session is not None:
+        db.session.remove()
+    db.remove_db()
 
-    def tearDown(self):
-        if db._session is not None:
-            db.session.remove()
-        db.remove_db()
-        if os.path.exists(self._dir):
-            shutil.rmtree(self._dir)
 
-    def test_server_debug(self):
-        args = app.create_parser().parse_args(
-            ['--db', self._db_url, 'server', '-H', 'test.domain',
-             '-p', '5001', '-d'])
-        assert args.host == 'test.domain'
-        assert args.port == 5001
-        assert args.debug
-        assert args.db == self._db_url
+def test_server_debug(db_url):
+    args = app.create_parser().parse_args(
+        ['--db', db_url, 'server', '-H', 'test.domain', '-p', '5001', '-d'])
+    assert args.host == 'test.domain'
+    assert args.port == 5001
+    assert args.debug
+    assert args.db == db_url
 
-        mock_app = MagicMock()
-        mock_app_creator = MagicMock(return_value=mock_app)
-        with patch('werkzeug.serving.run_simple', MagicMock()) as f, \
-                patch('chainerui.app.create_app', mock_app_creator):
-            args.handler(args)
-            f.assert_not_called()
-
-            db.upgrade()
-            args.handler(args)
-            f.assert_called_once()
-            f.assert_called_with(
-                'test.domain', 5001, mock_app, use_reloader=True,
-                use_debugger=True, threaded=True)
-
-    def test_server_production(self):
-        args = app.create_parser().parse_args(
-            ['--db', self._db_url, 'server', '-H', 'test.domain',
-             '-p', '5001'])
-        assert args.host == 'test.domain'
-        assert args.port == 5001
-        assert not args.debug
-        assert args.db == self._db_url
-
-        mock_app = MagicMock()
-        mock_app_creator = MagicMock(return_value=mock_app)
-        mock_server = MagicMock()
-        mock_server_init = MagicMock(return_value=mock_server)
-        with patch('gevent.pywsgi.WSGIServer', mock_server_init), \
-                patch('chainerui.app.create_app', mock_app_creator):
-            args.handler(args)
-            mock_server.serve_forever.assert_not_called()
-
-            db.upgrade()
-            args.handler(args)
-            mock_server.serve_forever.assert_called_once()
-
-    def test_project_create(self):
-        args = app.create_parser().parse_args(
-            ['--db', self._db_url, 'project', 'create', '-d', self._dir,
-             '-n', 'test'])
-        assert args.project_dir == self._dir
-        assert args.project_name == 'test'
-        assert args.db == self._db_url
-
+    mock_app = MagicMock()
+    mock_app_creator = MagicMock(return_value=mock_app)
+    with patch('werkzeug.serving.run_simple', MagicMock()) as f, \
+            patch('chainerui.app.create_app', mock_app_creator):
         args.handler(args)
+        f.assert_not_called()
+
         db.upgrade()
-        p = db.session.query(Project).filter_by(path_name=self._dir).first()
-        assert p is None
-        # on Windows/Python2, another session is create, need to remove
-        # this session externally (*)
-        db._session.remove()
-
         args.handler(args)
-        p = db.session.query(Project).filter_by(path_name=self._dir).first()
-        assert p is not None
-        assert p.path_name == self._dir
-        assert p.name == 'test'
-        db._session.remove()  # same as (*)
+        f.assert_called_once()
+        f.assert_called_with(
+            'test.domain', 5001, mock_app, use_reloader=True,
+            use_debugger=True, threaded=True)
 
-        args.handler(args)  # already registered, confirm not occur error
-        ps = db.session.query(Project).filter_by(path_name=self._dir).all()
-        assert len(ps) == 1
 
-    def test_db_create(self):
-        args = app.create_parser().parse_args(
-            ['--db', self._db_url, 'db', 'create'])
-        assert args.type == 'create'
-        assert args.db == self._db_url
+def test_server_production(db_url):
+    args = app.create_parser().parse_args(
+        ['--db', db_url, 'server', '-H', 'test.domain', '-p', '5001'])
+    assert args.host == 'test.domain'
+    assert args.port == 5001
+    assert not args.debug
+    assert args.db == db_url
+
+    mock_app = MagicMock()
+    mock_app_creator = MagicMock(return_value=mock_app)
+    mock_server = MagicMock()
+    mock_server_init = MagicMock(return_value=mock_server)
+    with patch('gevent.pywsgi.WSGIServer', mock_server_init), \
+            patch('chainerui.app.create_app', mock_app_creator):
         args.handler(args)
-        assert os.path.isdir(db._sqlite_default_db_dir())
-        assert not db._initialized
+        mock_server.serve_forever.assert_not_called()
 
-    def test_db_status(self):
-        args = app.create_parser().parse_args(
-            ['--db', self._db_url, 'db', 'status'])
-        assert args.type == 'status'
-        assert args.db == self._db_url
+        db.upgrade()
         args.handler(args)
-        assert db._initialized
-        assert db._external_db
+        mock_server.serve_forever.assert_called_once()
 
-    def test_db_upgrade_drop(self):
-        args = app.create_parser().parse_args(
-            ['--db', self._db_url, 'db', 'upgrade'])
-        assert args.type == 'upgrade'
-        assert args.db == self._db_url
+
+def test_project_create(func_dir, db_url):
+    args = app.create_parser().parse_args(
+        ['--db', db_url, 'project', 'create', '-d', func_dir, '-n', 'test'])
+    assert args.project_dir == func_dir
+    assert args.project_name == 'test'
+    assert args.db == db_url
+
+    args.handler(args)
+    db.upgrade()
+    p = db.session.query(Project).filter_by(path_name=func_dir).first()
+    assert p is None
+    # on Windows/Python2, another session is create, need to remove
+    # this session externally (*)
+    db._session.remove()
+
+    args.handler(args)
+    p = db.session.query(Project).filter_by(path_name=func_dir).first()
+    assert p is not None
+    assert p.path_name == func_dir
+    assert p.name == 'test'
+    db._session.remove()  # same as (*)
+
+    args.handler(args)  # already registered, confirm not occur error
+    ps = db.session.query(Project).filter_by(path_name=func_dir).all()
+    assert len(ps) == 1
+
+
+def test_db_create(db_url):
+    args = app.create_parser().parse_args(['--db', db_url, 'db', 'create'])
+    assert args.type == 'create'
+    assert args.db == db_url
+    args.handler(args)
+    assert os.path.isdir(db._sqlite_default_db_dir())
+    assert not db._initialized
+
+
+def test_db_status(db_url):
+    args = app.create_parser().parse_args(['--db', db_url, 'db', 'status'])
+    assert args.type == 'status'
+    assert args.db == db_url
+    args.handler(args)
+    assert db._initialized
+    assert db._external_db
+
+
+def test_db_upgrade_drop(db_url):
+    args = app.create_parser().parse_args(['--db', db_url, 'db', 'upgrade'])
+    assert args.type == 'upgrade'
+    assert args.db == db_url
+    args.handler(args)
+    assert db._initialized
+    assert db._external_db
+
+    args = app.create_parser().parse_args(
+        ['--db', db_url, 'db', 'drop'])
+    assert args.type == 'drop'
+    assert args.db == db_url
+    args.handler(args)
+    assert not db._initialized
+    assert not db._external_db
+
+
+def test_db_revision(db_url):
+    args = app.create_parser().parse_args(['--db', db_url, 'db', 'revision'])
+    assert args.type == 'revision'
+    assert args.db == db_url
+    with patch('chainerui.app.db_revision.new_revision') as f:
         args.handler(args)
-        assert db._initialized
-        assert db._external_db
-
-        args = app.create_parser().parse_args(
-            ['--db', self._db_url, 'db', 'drop'])
-        assert args.type == 'drop'
-        assert args.db == self._db_url
-        args.handler(args)
-        assert not db._initialized
-        assert not db._external_db
-
-    def test_db_revision(self):
-        args = app.create_parser().parse_args(
-            ['--db', self._db_url, 'db', 'revision'])
-        assert args.type == 'revision'
-        assert args.db == self._db_url
-        with patch('chainerui.app.db_revision.new_revision') as f:
-            args.handler(args)
-            assert f.called
-        assert db._initialized
-        assert db._external_db
+        assert f.called
+    assert db._initialized
+    assert db._external_db

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,32 +2,19 @@ from mock import MagicMock
 from mock import patch
 import os
 
-import pytest
-
 from chainerui import app
 from chainerui import db
 from chainerui.models.project import Project
 
 
-@pytest.fixture(autouse=True, scope='function')
-def db_url(func_dir):
-    db_path = os.path.join(func_dir, 'test_app.db')
-    db_url = 'sqlite:///' + db_path
-    yield(db_url)
-
-    if db._session is not None:
-        db.session.remove()
-    db.remove_db()
-
-
-def test_server_debug(db_url):
+def test_server_debug(func_init_db):
     args = app.create_parser().parse_args(
-        ['--db', db_url, '--db-echo', 'server', '-H', 'test.domain', '-p',
+        ['--db', db.url, '--db-echo', 'server', '-H', 'test.domain', '-p',
          '5001', '-d'])
     assert args.host == 'test.domain'
     assert args.port == 5001
     assert args.debug
-    assert args.db == db_url
+    assert args.db == db.url
     assert args.db_echo
 
     mock_app = MagicMock()
@@ -45,13 +32,13 @@ def test_server_debug(db_url):
             use_debugger=True, threaded=True)
 
 
-def test_server_production(db_url):
+def test_server_production(func_init_db):
     args = app.create_parser().parse_args(
-        ['--db', db_url, 'server', '-H', 'test.domain', '-p', '5001'])
+        ['--db', db.url, 'server', '-H', 'test.domain', '-p', '5001'])
     assert args.host == 'test.domain'
     assert args.port == 5001
     assert not args.debug
-    assert args.db == db_url
+    assert args.db == db.url
     assert not args.db_echo
 
     mock_app = MagicMock()
@@ -68,12 +55,12 @@ def test_server_production(db_url):
         mock_server.serve_forever.assert_called_once()
 
 
-def test_project_create(func_dir, db_url):
+def test_project_create(func_dir, func_init_db):
     args = app.create_parser().parse_args(
-        ['--db', db_url, 'project', 'create', '-d', func_dir, '-n', 'test'])
+        ['--db', db.url, 'project', 'create', '-d', func_dir, '-n', 'test'])
     assert args.project_dir == func_dir
     assert args.project_name == 'test'
-    assert args.db == db_url
+    assert args.db == db.url
 
     args.handler(args)
     db.upgrade()
@@ -95,7 +82,8 @@ def test_project_create(func_dir, db_url):
     assert len(ps) == 1
 
 
-def test_db_create(db_url):
+def test_db_create(func_dir):
+    db_url = os.path.join(func_dir, 'chainerui.db')
     args = app.create_parser().parse_args(['--db', db_url, 'db', 'create'])
     assert args.type == 'create'
     assert args.db == db_url
@@ -104,36 +92,36 @@ def test_db_create(db_url):
     assert not db._initialized
 
 
-def test_db_status(db_url):
-    args = app.create_parser().parse_args(['--db', db_url, 'db', 'status'])
+def test_db_status(func_init_db):
+    args = app.create_parser().parse_args(['--db', db.url, 'db', 'status'])
     assert args.type == 'status'
-    assert args.db == db_url
+    assert args.db == db.url
     args.handler(args)
     assert db._initialized
     assert db._external_db
 
 
-def test_db_upgrade_drop(db_url):
-    args = app.create_parser().parse_args(['--db', db_url, 'db', 'upgrade'])
+def test_db_upgrade_drop(func_init_db):
+    args = app.create_parser().parse_args(['--db', db.url, 'db', 'upgrade'])
     assert args.type == 'upgrade'
-    assert args.db == db_url
+    assert args.db == db.url
     args.handler(args)
     assert db._initialized
     assert db._external_db
 
     args = app.create_parser().parse_args(
-        ['--db', db_url, 'db', 'drop'])
+        ['--db', db.url, 'db', 'drop'])
     assert args.type == 'drop'
-    assert args.db == db_url
+    assert args.db == db.url
     args.handler(args)
     assert not db._initialized
     assert not db._external_db
 
 
-def test_db_revision(db_url):
-    args = app.create_parser().parse_args(['--db', db_url, 'db', 'revision'])
+def test_db_revision(func_init_db):
+    args = app.create_parser().parse_args(['--db', db.url, 'db', 'revision'])
     assert args.type == 'revision'
-    assert args.db == db_url
+    assert args.db == db.url
     with patch('chainerui.app.db_revision.new_revision') as f:
         args.handler(args)
         assert f.called

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,54 +1,41 @@
 from mock import MagicMock
-import unittest
 
+import pytest
 from six import string_types
 from sqlalchemy.exc import OperationalError
 
-from chainerui import CHAINERUI_ENV
-from chainerui import create_app
 from chainerui import db
 from tests.helpers import assert_json_api
-from tests.helpers import NotInTestEnvironmentException
 
 
-class TestInit(unittest.TestCase):
+@pytest.fixture(autouse=True, scope='function')
+def setup_mock_db():
+    # not setup database
+    db._initialized = True
+    mock_session = MagicMock()
+    mock_session.query = MagicMock(
+        side_effect=OperationalError(None, None, None))
+    db._session = mock_session
 
-    @classmethod
-    def setUpClass(cls):
-        if not CHAINERUI_ENV == 'test':
-            raise NotInTestEnvironmentException(
-                'set environment variable CHAINERUI_ENV=test '
-                'when you run this test'
-            )
 
-    def setUp(self):
-        # not setup database
-        db._initialized = True
-        mock_session = MagicMock()
-        mock_session.query = MagicMock(
-            side_effect=OperationalError(None, None, None))
-        db._session = mock_session
+# GET /
+def test_get_index(app):
+    resp = app.get('/')
+    assert resp.status_code == 200
+    assert '<title>ChainerUI</title>' in resp.data.decode()
 
-        app = create_app()
-        app.testing = True
-        self.app = app.test_client()
 
-    # GET /
-    def test_get_index(self):
-        resp = self.app.get('/')
-        assert resp.status_code == 200
-        assert '<title>ChainerUI</title>' in resp.data.decode()
+# GET /favicon.ico
+def test_get_favicon(app):
+    resp = app.get('/favicon.ico')
+    assert resp.status_code == 200
 
-    # GET /favicon.ico
-    def test_get_favicon(self):
-        resp = self.app.get('/favicon.ico')
-        assert resp.status_code == 200
 
-    # raise an exception when GET /api/v1/projects
-    def test_handle_invalid_usage(self):
-        resp = self.app.get('/api/v1/projects')
-        data = assert_json_api(resp, 400)
-        assert len(data) == 1
-        assert len(data['error']) == 2
-        assert isinstance(data['error']['message'], string_types)
-        assert 'DBOperationalError' == data['error']['type']
+# raise an exception when GET /api/v1/projects
+def test_handle_invalid_usage(app):
+    resp = app.get('/api/v1/projects')
+    data = assert_json_api(resp, 400)
+    assert len(data) == 1
+    assert len(data['error']) == 2
+    assert isinstance(data['error']['message'], string_types)
+    assert 'DBOperationalError' == data['error']['type']

--- a/tests/utils_tests/test_db_revision.py
+++ b/tests/utils_tests/test_db_revision.py
@@ -1,40 +1,19 @@
-import unittest
-
 from alembic.command import upgrade
 
-from chainerui import CHAINERUI_ENV
 from chainerui import db
 from chainerui.utils.db_revision import check_current_db_revision
 
-from tests.helpers import NotInTestEnvironmentException
+
+def _upgrade():
+    config = db.alembic_config
+    upgrade(config, '213e2a3392f2')  # = init revision
 
 
-class DBRevision(unittest.TestCase):
+def test_check_current_db_revision(func_init_db):
+    assert not check_current_db_revision()
 
-    @classmethod
-    def setUpClass(cls):
-        if not CHAINERUI_ENV == 'test':
-            raise NotInTestEnvironmentException(
-                'set environment variable CHAINERUI_ENV=test '
-                'when you run this test'
-            )
-        db.init_db()
-        db.setup(test_mode=True)
+    _upgrade()
+    assert not check_current_db_revision()
 
-    @classmethod
-    def tearDownClass(cls):
-        db.session.remove()
-        db.remove_db()
-
-    def _upgrade(self):
-        config = db.alembic_config
-        upgrade(config, '213e2a3392f2')  # = init revision
-
-    def test_check_current_db_revision(self):
-        assert not check_current_db_revision()
-
-        self._upgrade()
-        assert not check_current_db_revision()
-
-        db.upgrade()
-        assert check_current_db_revision()
+    db.upgrade()
+    assert check_current_db_revision()

--- a/tests/utils_tests/test_log_report.py
+++ b/tests/utils_tests/test_log_report.py
@@ -1,23 +1,14 @@
 import json
 import os
-import shutil
-import tempfile
-import unittest
 
 from chainerui.utils import log_report
+from tests.conftest import TempDirTestCase
 
 
-class TestLogReport(unittest.TestCase):
-
-    def setUp(self):
-        self._dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        if os.path.exists(self._dir):
-            shutil.rmtree(self._dir)
+class TestLogReport(TempDirTestCase):
 
     def test_add_log_without_elapsed_time(self):
-        test_dir = os.path.join(self._dir, 'result')
+        test_dir = os.path.join(self.dir, 'result')
         target = log_report.LogReport(test_dir, {'batchsize': 100})
         assert os.path.exists(test_dir)
         assert os.path.exists(os.path.join(test_dir, 'args'))
@@ -48,7 +39,7 @@ class TestLogReport(unittest.TestCase):
         assert target_log1['elapsed_time'] > 0
 
     def test_add_log_with_elapsed_time(self):
-        test_dir = os.path.join(self._dir, 'result2')
+        test_dir = os.path.join(self.dir, 'result2')
         target = log_report.LogReport(test_dir)
         assert os.path.exists(test_dir)
         assert not os.path.exists(os.path.join(test_dir, 'args'))

--- a/tests/utils_tests/test_save_args.py
+++ b/tests/utils_tests/test_save_args.py
@@ -1,63 +1,52 @@
 import argparse
 import json
 import os
-import shutil
-import tempfile
-import unittest
 
 from chainerui.utils import save_args
 
 
-class TestSaveArgs(unittest.TestCase):
+def test_save_args_dict(func_dir):
+    out_path = os.path.join(func_dir, 'result')
+    conditions = {
+        'int': 1, 'float': 0.1, 'str': 'foo',
+        'inner': {'int': 1}, 'array': ['boo']
+    }
+    save_args(conditions, out_path)
 
-    def setUp(self):
-        self._dir = tempfile.mkdtemp()
+    args_path = os.path.join(out_path, 'args')
+    assert os.path.exists(args_path)
 
-    def tearDown(self):
-        if os.path.exists(self._dir):
-            shutil.rmtree(self._dir)
+    with open(args_path) as f:
+        target = json.load(f)
 
-    def test_save_args_dict(self):
-        out_path = os.path.join(self._dir, 'result')
-        conditions = {
-            'int': 1, 'float': 0.1, 'str': 'foo',
-            'inner': {'int': 1}, 'array': ['boo']
-        }
-        save_args(conditions, out_path)
+    assert len(target) == 5
+    assert target['int'] == 1
+    assert target['float'] == 0.1
+    assert target['str'] == 'foo'
+    assert target['inner'] == {'int': 1}
+    assert target['array'] == ['boo']
 
-        args_path = os.path.join(out_path, 'args')
-        assert os.path.exists(args_path)
 
-        with open(args_path) as f:
-            target = json.load(f)
+def _create_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', type=int)
+    parser.add_argument('-s')
+    parser.add_argument('-a', nargs='+', type=int)
+    return parser
 
-        assert len(target) == 5
-        assert target['int'] == 1
-        assert target['float'] == 0.1
-        assert target['str'] == 'foo'
-        assert target['inner'] == {'int': 1}
-        assert target['array'] == ['boo']
 
-    def _create_parser(self):
-        parser = argparse.ArgumentParser()
-        parser.add_argument('-i', type=int)
-        parser.add_argument('-s')
-        parser.add_argument('-a', nargs='+', type=int)
-        return parser
+def test_save_args_argparse(func_dir):
+    out_path = os.path.join(func_dir, 'result2')
+    parser = _create_parser()
+    args = parser.parse_args(['-s', 'foo', '-i', '-1', '-a', '0', '100'])
+    save_args(args, out_path)
 
-    def test_save_args_argparse(self):
-        out_path = os.path.join(self._dir, 'result2')
-        parser = self._create_parser()
-        args = parser.parse_args(
-            ['-s', 'foo', '-i', '-1', '-a', '0', '100'])
-        save_args(args, out_path)
+    args_path = os.path.join(out_path, 'args')
+    assert os.path.exists(args_path)
 
-        args_path = os.path.join(out_path, 'args')
-        assert os.path.exists(args_path)
-
-        with open(args_path) as f:
-            target = json.load(f)
-        assert len(target) == 3
-        assert target['i'] == -1
-        assert target['s'] == 'foo'
-        assert target['a'] == [0, 100]
+    with open(args_path) as f:
+        target = json.load(f)
+    assert len(target) == 3
+    assert target['i'] == -1
+    assert target['s'] == 'foo'
+    assert target['a'] == [0, 100]


### PR DESCRIPTION
depends #190, #191 

Currently ChainerUI support external db, tests can set own database. This PR use own database file on every function (if needed). By this PR and #191, `CHAINERUI_ENV` have no role, so removed.

* add `func_db` and `func_init_db` fixture
* remove setUp and tearDown to make test database
* current tests use class method even if targets are function (not class module), modify them as "function"