### PR TITLE
Fix minversion as string type to pass pytest's version check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test
 python_functions = test
-minversion = 3.4
+minversion = '3.4'


### PR DESCRIPTION
fixes #203 