### PR TITLE
Restore tooltip option on line chart

### DIFF
--- a/frontend/src/components/LogVisualizer.jsx
+++ b/frontend/src/components/LogVisualizer.jsx
@@ -7,7 +7,8 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  ResponsiveContainer
+  ResponsiveContainer,
+  Tooltip
 } from 'recharts';
 
 import * as uiPropTypes from '../store/uiPropTypes';
@@ -22,6 +23,7 @@ import {
   downloadChartAsPng
 } from '../utils';
 import LogVisualizerLegend from './LogVisualizerLegend';
+import LogVisualizerTooltip from './LogVisualizerTooltip';
 
 
 const getDomain = (axisConfig = {}) => {
@@ -168,6 +170,7 @@ class LogVisualizer extends React.Component {
               <CartesianGrid strokeDasharray="3 3" />
               {lineElems.yLeftAxis}
               {lineElems.yRightAxis}
+              <Tooltip content={<LogVisualizerTooltip xAxisKey={xAxisKey} />} />
             </LineChart>
           </ResponsiveContainer>
           <div>

--- a/frontend/src/components/LogVisualizerTooltip.jsx
+++ b/frontend/src/components/LogVisualizerTooltip.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  formatLogValue, formatLogTooltipLabel
+} from '../utils';
+
+
+const renderItems = (payload, formatter) => (
+  payload.filter((entry) => entry.value != null).map((entry) => {
+    const { dataKey, color, value } = entry;
+    return (
+      <li
+        className="list-group-item py-0"
+        key={dataKey}
+        style={{ borderLeft: `3px solid ${color}` }}
+      >
+        {formatter(value)}
+      </li>
+    );
+  })
+);
+
+const LogVisualizerTooltip = (props) => {
+  const { xAxisKey, label, payload } = props;
+
+  if (!payload || payload.length === 0) {
+    return null;
+  }
+
+  const labelFormatter = formatLogTooltipLabel(xAxisKey);
+  const formatter = formatLogValue();
+
+  return (
+    <div className="log-visualizer-tooltip card">
+      <div className="card-body px-2 py-0">
+        <h6 className="cart-title my-2">{labelFormatter(label)}</h6>
+      </div>
+      <ul className="list-group list-group-flush small">
+        {renderItems(payload, formatter)}
+      </ul>
+    </div>
+  );
+};
+
+LogVisualizerTooltip.propTypes = {
+  xAxisKey: PropTypes.string.isRequired,
+  // passed by reactstrap Tooltip
+  label: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  // passed by reactstrap Tooltip
+  payload: PropTypes.arrayOf(PropTypes.any)
+};
+
+LogVisualizerTooltip.defaultProps = {
+  xAxisKey: '',
+  label: undefined,
+  payload: []
+};
+
+export default LogVisualizerTooltip;

--- a/frontend/src/components/LogVisualizerTooltip.jsx
+++ b/frontend/src/components/LogVisualizerTooltip.jsx
@@ -43,7 +43,7 @@ const LogVisualizerTooltip = (props) => {
 };
 
 LogVisualizerTooltip.propTypes = {
-  xAxisKey: PropTypes.string.isRequired,
+  xAxisKey: PropTypes.string,
   // passed by reactstrap Tooltip
   label: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   // passed by reactstrap Tooltip

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -41,6 +41,10 @@
   overflow: auto;
 }
 
+.log-visualizer-tooltip {
+  max-width: 300px;
+}
+
 .ReactTable {
   display: table;
 }


### PR DESCRIPTION
fixes #202 

![image](https://user-images.githubusercontent.com/414255/48048919-61879700-e1e0-11e8-9d5f-2d2b831531db.png)

- revert `LogVisualizerTooltip` component
- show only values, result id and key name is hidden