### PR TITLE
Destroy `mapEntitiesToStats`

### DIFF
--- a/frontend/src/containers/PlotContainer.jsx
+++ b/frontend/src/containers/PlotContainer.jsx
@@ -28,7 +28,7 @@ import ExperimentsTableConfigurator from '../components/ExperimentsTableConfigur
 import LogVisualizer from '../components/LogVisualizer';
 import NavigationBar from '../components/NavigationBar';
 import SideBar from '../components/SideBar';
-import { defaultProjectStatus, defaultProjectConfig, keyOptions } from '../constants';
+import { defaultProjectStatus, defaultProjectConfig } from '../constants';
 import { startPolling, stopPolling } from '../utils';
 
 
@@ -143,26 +143,6 @@ class PlotContainer extends React.Component {
   }
 }
 
-const mapEntitiesToStats = (entities) => {
-  const { results = {} } = entities;
-  const argKeySet = {};
-  const logKeySet = {};
-  Object.keys(results).forEach((resultId) => {
-    const result = results[resultId];
-    result.args.forEach((arg) => { argKeySet[arg.key] = true; });
-    result.logs.forEach((log) => {
-      log.logItems.forEach((logItem) => {
-        logKeySet[logItem.key] = true;
-      });
-    });
-  });
-  const argKeys = Object.keys(argKeySet);
-  const logKeys = Object.keys(logKeySet).sort();
-  const xAxisKeys = keyOptions.filter((key) => key in logKeySet);
-
-  return { argKeys, logKeys, xAxisKeys };
-};
-
 const mapStateToProps = (state, ownProps) => {
   const projectId = Number(ownProps.params.projectId);
   const {
@@ -176,7 +156,7 @@ const mapStateToProps = (state, ownProps) => {
   const projectStatus = status.projectsStatus[projectId] || defaultProjectStatus;
   const projectConfig = config.projectsConfig[projectId] || defaultProjectConfig;
   const globalConfig = config.global;
-  const stats = mapEntitiesToStats(entities);
+  const { stats } = status;
 
   return {
     projectId,

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -47,9 +47,9 @@ const resultsReducer = (state = {}, action) => {
   switch (action.type) {
     case ActionTypes.RESULT_LIST_SUCCESS:
       if (action.response && action.response.results) {
-        const resultsList = action.response.results;
+        const resultList = action.response.results;
         const results = {};
-        resultsList.forEach((result) => {
+        resultList.forEach((result) => {
           results[result.id] = result;
         });
         return results;

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -48,11 +48,16 @@ const resultsReducer = (state = {}, action) => {
     case ActionTypes.RESULT_LIST_SUCCESS:
       if (action.response && action.response.results) {
         const resultList = action.response.results;
+        const resultIds = resultList.map((result) => result.id);
+        let modified = Object.keys(state).length !== resultIds.length;
         const results = {};
         resultList.forEach((result) => {
-          results[result.id] = result;
+          const oldResult = state[result.id] || {};
+          const resultModified = oldResult.logModifiedAt !== result.logModifiedAt;
+          results[result.id] = resultModified ? result : oldResult;
+          modified = modified || resultModified;
         });
-        return results;
+        return modified ? results : state;
       }
       return state;
     case ActionTypes.RESULT_SUCCESS:


### PR DESCRIPTION
PlotContainer's `mapEntitiesToStats` function is a bad.
This always creates a new object, so a component having stats does not work to compare objects on `shouldComponentUpdate`.
We must solve this problem for performance tuning.

Therefore, I moved the `stats` to the `status.stats` in the store. Also I suppressed excessive update store's `entities.results` on `RESULT_LIST_SUCCESS` action.