### PR TITLE
Avoid to return None type on command or snapshot ID

### DIFF
--- a/chainerui/models/command.py
+++ b/chainerui/models/command.py
@@ -23,6 +23,9 @@ class Command(database.BASE):
         self.request = json.dumps(request, indent=4)
         self.response = json.dumps(response, indent=4)
 
+    def update(self, response=None):
+        self.response = json.dumps(response, indent=4)
+
     def __repr__(self):
         return '<Command id: %r />' % (self.id)
 
@@ -39,7 +42,6 @@ class Command(database.BASE):
             response = None
         else:
             response = json.loads(self.response)
-
         return {
             'id': self.id,
             'name': self.name,

--- a/chainerui/models/command.py
+++ b/chainerui/models/command.py
@@ -42,6 +42,7 @@ class Command(database.BASE):
             response = None
         else:
             response = json.loads(self.response)
+
         return {
             'id': self.id,
             'name': self.name,

--- a/chainerui/tasks/crawl_result.py
+++ b/chainerui/tasks/crawl_result.py
@@ -94,6 +94,7 @@ def crawl_result(result, force=False, commit=True):
     # registered commands can be get response, so need to update
     current_cmd_idx = len(result.commands)
     if len(crawled_result['commands']) < current_cmd_idx:
+        current_cmd_idx = 0
         result.commands = []
         result.snapshots = []
     for cmd in crawled_result['commands'][current_cmd_idx:]:

--- a/chainerui/views/result.py
+++ b/chainerui/views/result.py
@@ -40,8 +40,8 @@ class ResultAPI(MethodView):
             # have to call SELECT query again.
             for result in results:
                 crawl_result(result, commit=False)
-            rs = [r.serialize_with_sampled_logs(logs_limit) for r in results]
             db.session.commit()
+            rs = [r.serialize_with_sampled_logs(logs_limit) for r in results]
 
             return jsonify({'results': rs})
 


### PR DESCRIPTION
fixes #212 

IDs of Command and Snapshot object are set on commit phase, so `db.commit` needs to call before serialization. Additionally fix insertion process, avoid to insert new recorder every time.