### PR TITLE
Remove axisName from axisConfig

### DIFF
--- a/frontend/src/components/AxesConfigurator.jsx
+++ b/frontend/src/components/AxesConfigurator.jsx
@@ -22,15 +22,16 @@ const AxesConfigurator = (props) => {
     onAxisConfigLogKeySelectToggle
   } = props;
   const {
-    xAxis = { axisName: 'xAxis' },
-    yLeftAxis = { axisName: 'yLeftAxis' },
-    yRightAxis = { axisName: 'yRightAxis' }
+    xAxis = {},
+    yLeftAxis = {},
+    yRightAxis = {}
   } = projectConfig.axes;
 
   return (
     <div className="axes-configurator">
       <AxisConfigurator
         projectId={project.id}
+        axisName="yLeftAxis"
         axisConfig={yLeftAxis}
         onChangeScale={onAxisConfigScaleUpdate}
         onAxisConfigScaleRangeTypeUpdate={onAxisConfigScaleRangeTypeUpdate}
@@ -38,6 +39,7 @@ const AxesConfigurator = (props) => {
       >
         <AxisLogKeySelector
           projectId={project.id}
+          axisName="yLeftAxis"
           axisConfig={yLeftAxis}
           stats={stats}
           onAxisConfigLogKeySelectToggle={onAxisConfigLogKeySelectToggle}
@@ -54,6 +56,7 @@ const AxesConfigurator = (props) => {
       </AxisConfigurator>
       <AxisConfigurator
         projectId={project.id}
+        axisName="yRightAxis"
         axisConfig={yRightAxis}
         onChangeScale={onAxisConfigScaleUpdate}
         onAxisConfigScaleRangeTypeUpdate={onAxisConfigScaleRangeTypeUpdate}
@@ -61,6 +64,7 @@ const AxesConfigurator = (props) => {
       >
         <AxisLogKeySelector
           projectId={project.id}
+          axisName="yRightAxis"
           axisConfig={yRightAxis}
           stats={stats}
           onAxisConfigLogKeySelectToggle={onAxisConfigLogKeySelectToggle}
@@ -77,6 +81,7 @@ const AxesConfigurator = (props) => {
       </AxisConfigurator>
       <AxisConfigurator
         projectId={project.id}
+        axisName="xAxis"
         axisConfig={xAxis}
         onChangeScale={onAxisConfigScaleUpdate}
         onAxisConfigScaleRangeTypeUpdate={onAxisConfigScaleRangeTypeUpdate}

--- a/frontend/src/components/AxisConfigurator.jsx
+++ b/frontend/src/components/AxisConfigurator.jsx
@@ -20,8 +20,7 @@ class AxisConfigurator extends React.Component {
   }
 
   handleChangeScale(scale) {
-    const { projectId, axisConfig } = this.props;
-    const { axisName } = axisConfig;
+    const { projectId, axisName } = this.props;
     this.props.onChangeScale(projectId, axisName, scale);
   }
 
@@ -34,10 +33,11 @@ class AxisConfigurator extends React.Component {
   render() {
     const {
       projectId,
+      axisName,
       axisConfig,
       onAxisConfigScaleRangeTypeUpdate, onAxisConfigScaleRangeNumberUpdate
     } = this.props;
-    const { axisName, scale } = axisConfig;
+    const { scale } = axisConfig;
 
     return (
       <div className="axis-configurator card">
@@ -51,6 +51,7 @@ class AxisConfigurator extends React.Component {
           <Collapse isOpen={this.state.showRangeConfig}>
             <AxisRangeConfigurator
               projectId={projectId}
+              axisName={axisName}
               axisConfig={axisConfig}
               isMin={false}
               onAxisConfigScaleRangeTypeUpdate={onAxisConfigScaleRangeTypeUpdate}
@@ -58,6 +59,7 @@ class AxisConfigurator extends React.Component {
             />
             <AxisRangeConfigurator
               projectId={projectId}
+              axisName={axisName}
               axisConfig={axisConfig}
               isMin
               onAxisConfigScaleRangeTypeUpdate={onAxisConfigScaleRangeTypeUpdate}
@@ -73,6 +75,7 @@ class AxisConfigurator extends React.Component {
 
 AxisConfigurator.propTypes = {
   projectId: uiPropTypes.projectId.isRequired,
+  axisName: uiPropTypes.axisName.isRequired,
   axisConfig: uiPropTypes.axisConfig.isRequired,
   onChangeScale: PropTypes.func.isRequired,
   onAxisConfigScaleRangeTypeUpdate: PropTypes.func.isRequired,

--- a/frontend/src/components/AxisLogKeySelector.jsx
+++ b/frontend/src/components/AxisLogKeySelector.jsx
@@ -13,8 +13,7 @@ class AxisLogKeySelector extends React.Component {
   }
 
   handleLogKeySelectToggle(logKey) {
-    const { projectId, axisConfig, onAxisConfigLogKeySelectToggle } = this.props;
-    const { axisName } = axisConfig;
+    const { projectId, axisName, onAxisConfigLogKeySelectToggle } = this.props;
     onAxisConfigLogKeySelectToggle(projectId, axisName, logKey);
   }
 
@@ -45,6 +44,7 @@ class AxisLogKeySelector extends React.Component {
 
 AxisLogKeySelector.propTypes = {
   projectId: uiPropTypes.projectId.isRequired,
+  axisName: uiPropTypes.axisName.isRequired,
   axisConfig: uiPropTypes.axisConfig.isRequired,
   stats: uiPropTypes.stats.isRequired,
   onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired

--- a/frontend/src/components/AxisRangeConfigurator.jsx
+++ b/frontend/src/components/AxisRangeConfigurator.jsx
@@ -14,14 +14,18 @@ class AxisRangeConfigurator extends React.Component {
   }
 
   handleRangeTypeChange(e) {
-    const { projectId, axisConfig, isMin, onAxisConfigScaleRangeTypeUpdate } = this.props;
-    const { axisName, scale = 'linear' } = axisConfig;
+    const {
+      projectId, axisName, axisConfig, isMin, onAxisConfigScaleRangeTypeUpdate
+    } = this.props;
+    const { scale = 'linear' } = axisConfig;
     onAxisConfigScaleRangeTypeUpdate(projectId, axisName, scale, isMin, e.target.value);
   }
 
   handleNumberChange(e) {
-    const { projectId, axisConfig, isMin, onAxisConfigScaleRangeNumberUpdate } = this.props;
-    const { axisName, scale = 'linear' } = axisConfig;
+    const {
+      projectId, axisName, axisConfig, isMin, onAxisConfigScaleRangeNumberUpdate
+    } = this.props;
+    const { scale = 'linear' } = axisConfig;
 
     let rangeNumber = null;
     if (e.target.value) {
@@ -104,6 +108,7 @@ class AxisRangeConfigurator extends React.Component {
 
 AxisRangeConfigurator.propTypes = {
   projectId: uiPropTypes.projectId.isRequired,
+  axisName: uiPropTypes.axisName.isRequired,
   axisConfig: uiPropTypes.axisConfig.isRequired,
   isMin: PropTypes.bool.isRequired,
   onAxisConfigScaleRangeTypeUpdate: PropTypes.func.isRequired,

--- a/frontend/src/components/LogVisualizer.jsx
+++ b/frontend/src/components/LogVisualizer.jsx
@@ -99,9 +99,9 @@ class LogVisualizer extends React.Component {
     const { axes, resultsConfig, lines } = projectConfig;
     const { logKeys, xAxisKeys } = stats;
     const {
-      xAxis = { axisName: 'xAxis' },
-      yLeftAxis = { axisName: 'yLeftAxis' },
-      yRightAxis = { axisName: 'yRightAxis' }
+      xAxis = {},
+      yLeftAxis = {},
+      yRightAxis = {}
     } = axes;
     const { xAxisKey = xAxisKeys[0] } = xAxis;
     const selectedResults = getSelectedResults(results, resultsConfig);

--- a/frontend/src/constants/index.js
+++ b/frontend/src/constants/index.js
@@ -89,7 +89,6 @@ export const logsLimitOptions = [
 
 export const defaultAxisConfig = {
   yLeftAxis: {
-    axisName: 'yLeftAxis',
     logKeysConfig: {
       'main/loss': {
         selected: true

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -281,7 +281,7 @@ const axesConfigReducer = (state = defaultAxisConfig, action) => {
     rangeType = 'auto',
     isMin, rangeNumber
   } = action;
-  const axisConfig = state[axisName] || { axisName };
+  const axisConfig = state[axisName] || {};
   const { logKeysConfig = {}, scaleRange = {} } = axisConfig;
   const idx = isMin ? 0 : 1;
   const rangeConfig = scaleRange[scale] || {};

--- a/frontend/src/store/uiPropTypes.js
+++ b/frontend/src/store/uiPropTypes.js
@@ -110,7 +110,6 @@ const logKeysConfig = PropTypes.objectOf(logKeyConfig);
 export const axisName = PropTypes.string;
 
 export const axisConfig = PropTypes.shape({
-  axisName: axisName.isRequired,
   logKeysConfig,
   scale: PropTypes.string,
   scaleRange: PropTypes.objectOf(PropTypes.shape({

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -132,9 +132,9 @@ export const getLogData = (results, stats, projectConfig) => {
   const { logKeys = [], xAxisKeys } = stats;
 
   const {
-    xAxis = { axisName: 'xAxis' },
-    yLeftAxis = { axisName: 'yLeftAxis' },
-    yRightAxis = { axisName: 'yRightAxis' }
+    xAxis = {},
+    yLeftAxis = {},
+    yRightAxis = {}
   } = axes || {};
   const { xAxisKey = xAxisKeys[0] } = xAxis;
 
@@ -180,9 +180,9 @@ export const getPlotLogData = (results, stats, projectConfig) => {
   const { axes, resultsConfig = {} } = projectConfig;
   const { xAxisKeys } = stats;
   const {
-    xAxis = { axisName: 'xAxis' },
-    yLeftAxis = { axisName: 'yLeftAxis' },
-    yRightAxis = { axisName: 'yRightAxis' }
+    xAxis = {},
+    yLeftAxis = {},
+    yRightAxis = {}
   } = axes || {};
   const { xAxisKey = xAxisKeys[0] } = xAxis;
 


### PR DESCRIPTION
I removed axisConfig's `axisName` . This property is difficult to initialization.

From now on, axisName must be passed as props.
