### PR TITLE
Avoid overlapping of tooltip and another UI

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -67,3 +67,7 @@
 .recharts-active-dot {
   pointer-events: none;
 }
+
+.recharts-tooltip-wrapper {
+  z-index: 10000;
+}


### PR DESCRIPTION
ref: #209

I added z-index for `.recharts-tooltip-wrapper` to avoid overlapping of the tooltip and another UI.

The z-index value doesn't have a specific meaning.
We have to consider z-index management as a future plan.

before:
![2018-11-20 08 30 47](https://user-images.githubusercontent.com/4876459/48741471-9e529400-ec9e-11e8-8bce-d58041c729d7.png)

after:
![2018-11-20 08 30 35](https://user-images.githubusercontent.com/4876459/48741477-a27eb180-ec9e-11e8-953a-c8bcbe9b0141.png)
