### PR TITLE
Refactoring reducers

### DIFF
--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -438,29 +438,28 @@ const tableStateReducer = (state = {}, action) => {
   }
 };
 
+const projectConfigReducer = combineReducers({
+  axes: axesConfigReducer,
+  resultsConfig: resultsConfigReducer,
+  lines: linesConfigReducer,
+  tableState: tableStateReducer
+});
 
 const projectsConfigReducer = (state = {}, action) => {
   const { projectId } = action;
-
   if (projectId) {
-    let projectConfig;
     switch (action.type) {
       case ActionTypes.PROJECT_CONFIG_RESET:
-        projectConfig = {};
-        break;
+        return {
+          ...state,
+          [projectId]: projectConfigReducer(undefined, action)
+        };
       default:
-        projectConfig = state[projectId] || {};
+        return {
+          ...state,
+          [projectId]: projectConfigReducer(state[projectId], action)
+        };
     }
-
-    return {
-      ...state,
-      [projectId]: {
-        axes: axesConfigReducer(projectConfig.axes, action),
-        resultsConfig: resultsConfigReducer(projectConfig.resultsConfig, action),
-        lines: linesConfigReducer(projectConfig.lines, action),
-        tableState: tableStateReducer(projectConfig.tableState, action)
-      }
-    };
   }
 
   return state;

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -370,19 +370,19 @@ const resultsConfigWithoutResultReducer = (state, resultId) => {
 
 const resultsConfigReducer = (state = {}, action) => {
   const { resultId } = action;
-  const resultConfig = state[resultId] || {};
   switch (action.type) {
     case ActionTypes.RESULTS_CONFIG_SELECT_UPDATE:
-      if (resultId == null) {
-        return state;
+      if (resultId) {
+        const resultConfig = state[resultId] || {};
+        return {
+          ...state,
+          [resultId]: {
+            ...resultConfig,
+            hidden: action.hidden
+          }
+        };
       }
-      return {
-        ...state,
-        [Number(resultId)]: {
-          ...resultConfig,
-          hidden: action.hidden
-        }
-      };
+      return state;
     case ActionTypes.RESULT_UPDATE_SUCCESS:
       if (action.response && action.response.result) {
         const { result } = action.response;

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -4,7 +4,7 @@ import { persistReducer } from 'redux-persist';
 import { requestsReducer } from 'redux-requests';
 import storage from 'redux-persist/es/storage';
 import * as ActionTypes from '../actions';
-import { chartSizeOptions, pollingOptions, logsLimitOptions, defaultAxisConfig, defaultProjectStatus, keyOptions } from '../constants';
+import { chartSizeOptions, pollingOptions, logsLimitOptions, defaultAxisConfig, CHART_DOWNLOAD_STATUS, keyOptions } from '../constants';
 
 
 const projectsReducer = (state = {}, action) => {
@@ -176,17 +176,27 @@ const fetchStateReducer = (state = {}, action) => {
 };
 
 
-const resultStatusReducer = (state = {}, action) => {
+const chartDownloadStatusReducer = (state = CHART_DOWNLOAD_STATUS.NONE, action) => {
   switch (action.type) {
-    case ActionTypes.RESULT_SELECT_UPDATE:
-      return {
-        ...state,
-        selected: action.selected
-      };
+    case ActionTypes.CHART_DOWNLOAD_STATUS_UPDATE:
+      return action.chartDownloadStatus;
     default:
       return state;
   }
 };
+
+const resultSelectedReducer = (state = false, action) => {
+  switch (action.type) {
+    case ActionTypes.RESULT_SELECT_UPDATE:
+      return action.selected;
+    default:
+      return state;
+  }
+};
+
+const resultStatusReducer = combineReducers({
+  selected: resultSelectedReducer
+});
 
 const resultsStatusReducer = (state = {}, action) => {
   const { resultId } = action;
@@ -200,22 +210,10 @@ const resultsStatusReducer = (state = {}, action) => {
   return state;
 };
 
-const projectStatusReducer = (state = defaultProjectStatus, action) => {
-  switch (action.type) {
-    case ActionTypes.CHART_DOWNLOAD_STATUS_UPDATE: {
-      const { chartDownloadStatus } = action;
-      return {
-        ...state,
-        chartDownloadStatus
-      };
-    }
-    default:
-      return {
-        ...state,
-        resultsStatus: resultsStatusReducer(state.resultsStatus, action)
-      };
-  }
-};
+const projectStatusReducer = combineReducers({
+  chartDownloadStatus: chartDownloadStatusReducer,
+  resultsStatus: resultsStatusReducer
+});
 
 const projectsStatusReducer = (state = {}, action) => {
   const { projectId } = action;

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -200,33 +200,33 @@ const resultsStatusReducer = (state = {}, action) => {
   return state;
 };
 
-const projectsStatusReducer = (state = {}, action) => {
-  const { projectId } = action;
-  if (!projectId) {
-    return state;
-  }
-
-  const projectStatus = state[projectId] || defaultProjectStatus;
+const projectStatusReducer = (state = defaultProjectStatus, action) => {
   switch (action.type) {
     case ActionTypes.CHART_DOWNLOAD_STATUS_UPDATE: {
       const { chartDownloadStatus } = action;
       return {
         ...state,
-        [projectId]: {
-          ...projectStatus,
-          chartDownloadStatus
-        }
+        chartDownloadStatus
       };
     }
     default:
       return {
         ...state,
-        [projectId]: {
-          ...projectStatus,
-          resultsStatus: resultsStatusReducer(projectStatus.resultsStatus, action)
-        }
+        resultsStatus: resultsStatusReducer(state.resultsStatus, action)
       };
   }
+};
+
+const projectsStatusReducer = (state = {}, action) => {
+  const { projectId } = action;
+  if (projectId) {
+    return {
+      ...state,
+      [projectId]: projectStatusReducer(state[projectId], action)
+    };
+  }
+
+  return state;
 };
 
 const statsReducer = (state = { argKeys: [], logKeys: [], xAxisKeys: [] }, action) => {

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -271,17 +271,15 @@ const statusReducer = combineReducers({
 });
 
 
-const axesConfigReducer = (state = defaultAxisConfig, action) => {
+const axisConfigReducer = (state = {}, action) => {
   const {
-    axisName,
     logKey,
     scale = 'linear',
     xAxisKey,
     rangeType = 'auto',
     isMin, rangeNumber
   } = action;
-  const axisConfig = state[axisName] || {};
-  const { logKeysConfig = {}, scaleRange = {} } = axisConfig;
+  const { logKeysConfig = {}, scaleRange = {} } = state;
   const idx = isMin ? 0 : 1;
   const rangeConfig = scaleRange[scale] || {};
   const { rangeTypes = [], range = [] } = rangeConfig;
@@ -290,44 +288,32 @@ const axesConfigReducer = (state = defaultAxisConfig, action) => {
     case ActionTypes.AXIS_CONFIG_SCALE_UPDATE:
       return {
         ...state,
-        [axisName]: {
-          ...axisConfig,
-          scale
-        }
+        scale
       };
     case ActionTypes.AXIS_CONFIG_X_KEY_UPDATE:
       return {
         ...state,
-        [axisName]: {
-          ...axisConfig,
-          xAxisKey
-        }
+        xAxisKey
       };
     case ActionTypes.AXIS_CONFIG_SCALE_RANGE_TYPE_UPDATE:
       return {
         ...state,
-        [axisName]: {
-          ...axisConfig,
-          scaleRange: {
-            ...scaleRange,
-            [scale]: {
-              rangeTypes: Object.assign([], rangeTypes, { [idx]: rangeType }),
-              range
-            }
+        scaleRange: {
+          ...scaleRange,
+          [scale]: {
+            rangeTypes: Object.assign([], rangeTypes, { [idx]: rangeType }),
+            range
           }
         }
       };
     case ActionTypes.AXIS_CONFIG_SCALE_RANGE_NUMBER_UPDATE:
       return {
         ...state,
-        [axisName]: {
-          ...axisConfig,
-          scaleRange: {
-            ...scaleRange,
-            [scale]: {
-              rangeTypes,
-              range: Object.assign([], range, { [idx]: rangeNumber })
-            }
+        scaleRange: {
+          ...scaleRange,
+          [scale]: {
+            rangeTypes,
+            range: Object.assign([], range, { [idx]: rangeNumber })
           }
         }
       };
@@ -335,22 +321,30 @@ const axesConfigReducer = (state = defaultAxisConfig, action) => {
       const logKeyConfig = logKeysConfig[logKey] || {};
       return {
         ...state,
-        [axisName]: {
-          ...axisConfig,
-          logKeysConfig: {
-            ...logKeysConfig,
-            [logKey]: {
-              ...logKeyConfig,
-              selected: !logKeyConfig.selected
-            }
+        logKeysConfig: {
+          ...logKeysConfig,
+          [logKey]: {
+            ...logKeyConfig,
+            selected: !logKeyConfig.selected
           }
-
         }
       };
     }
     default:
       return state;
   }
+};
+
+const axesConfigReducer = (state = defaultAxisConfig, action) => {
+  const { axisName } = action;
+  if (axisName) {
+    return {
+      ...state,
+      [axisName]: axisConfigReducer(state[axisName], action)
+    };
+  }
+
+  return state;
 };
 
 

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -167,11 +167,7 @@ const fetchStateReducer = (state = {}, action) => {
     case ActionTypes.GLOBAL_CONFIG_POLLING_RATE_UPDATE:
     case LOCATION_CHANGE:
       if (action.pollingRate === 0) {
-        return {
-          ...state,
-          resultList: undefined,
-          result: undefined
-        };
+        return {};
       }
       return state;
     default:

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -176,25 +176,28 @@ const fetchStateReducer = (state = {}, action) => {
 };
 
 
-const resultsStatusReducer = (state = {}, action) => {
-  const { resultId } = action;
-  const resultStatus = state[resultId] || {};
-
+const resultStatusReducer = (state = {}, action) => {
   switch (action.type) {
     case ActionTypes.RESULT_SELECT_UPDATE:
-      if (resultId == null) {
-        return state;
-      }
       return {
         ...state,
-        [Number(resultId)]: {
-          ...resultStatus,
-          selected: action.selected
-        }
+        selected: action.selected
       };
     default:
       return state;
   }
+};
+
+const resultsStatusReducer = (state = {}, action) => {
+  const { resultId } = action;
+  if (resultId) {
+    return {
+      ...state,
+      [resultId]: resultStatusReducer(state[resultId], action)
+    };
+  }
+
+  return state;
 };
 
 const projectsStatusReducer = (state = {}, action) => {


### PR DESCRIPTION
I fixed reducers so that updating action does not unnecessarily update the store.
For example, both projectConfig and projectStatus are updated at the same time. I fixed.

And also, all reducers were rewrited that the last line is `return state`.