### PR TITLE
Add aggregation column on result table

### DIFF
--- a/frontend/src/components/ExperimentsTable.jsx
+++ b/frontend/src/components/ExperimentsTable.jsx
@@ -43,7 +43,7 @@ const ExperimentsTable = (props) => {
       onResultsConfigSelectUpdate(project.id, resultId, !evt.target.checked);
     });
   };
-  const handleGroupedResultsConfigSelectChange = (groupedResultKeys) => (evt) => {
+  const generateHandleGroupedResultsConfigSelectChange = (groupedResultKeys) => (evt) => {
     groupedResultKeys.forEach((resultId) => {
       onResultsConfigSelectUpdate(project.id, resultId, !evt.target.checked);
     });
@@ -98,7 +98,7 @@ const ExperimentsTable = (props) => {
           type="checkbox"
           checked={groupedVisibleResultCount > 0}
           style={{ opacity: isGroupedPartialSelect ? 0.5 : 1 }}
-          onChange={handleGroupedResultsConfigSelectChange(groupedResultKeys)}
+          onChange={generateHandleGroupedResultsConfigSelectChange(groupedResultKeys)}
         />;
       }
     },

--- a/frontend/src/store/uiPropTypes.js
+++ b/frontend/src/store/uiPropTypes.js
@@ -60,6 +60,7 @@ export const result = PropTypes.shape({
   id: resultId,
   pathName: PropTypes.string,
   name: PropTypes.string,
+  group: PropTypes.string,
   isUnregistered: PropTypes.bool,
   logs,
   args,


### PR DESCRIPTION
This PR provides grouping function to aggregate results on result table, the function is favor for categorizing results.

This PR includes only frontend part. To test the function, please add 'group' key manually on https://github.com/chainer/chainerui/blob/cb610fe0a6f036639211302aae214f651955e6ac/chainerui/models/result.py#L87-L97

For example add:

```
'group': 'AAA' if self.id % 2 == 0 else 'BBB'
```