### PR TITLE
Add checkbox to legend

### DIFF
--- a/frontend/src/components/LogVisualizer.jsx
+++ b/frontend/src/components/LogVisualizer.jsx
@@ -63,6 +63,7 @@ class LogVisualizer extends React.Component {
       projectConfig,
       globalConfig,
       onResultSelect,
+      onAxisConfigLogKeySelectToggle,
       stats
     } = this.props;
     const { resultsStatus = {} } = projectStatus;
@@ -98,6 +99,7 @@ class LogVisualizer extends React.Component {
           chartSize={chartSize}
           isResultNameAlignRight={isResultNameAlignRight}
           onResultSelect={onResultSelect}
+          onAxisConfigLogKeySelectToggle={onAxisConfigLogKeySelectToggle}
         />
         <Button size="sm" className="m-1" onClick={this.handleClickDownloadCode}>
           <span className="mx-1 oi oi-data-transfer-download" />code
@@ -118,7 +120,8 @@ LogVisualizer.propTypes = {
   projectConfig: uiPropTypes.projectConfig.isRequired,
   globalConfig: uiPropTypes.globalConfig.isRequired,
   onChartDownloadStatusUpdate: PropTypes.func.isRequired,
-  onResultSelect: PropTypes.func.isRequired
+  onResultSelect: PropTypes.func.isRequired,
+  onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired
 };
 
 export default LogVisualizer;

--- a/frontend/src/components/LogVisualizer.jsx
+++ b/frontend/src/components/LogVisualizer.jsx
@@ -82,6 +82,7 @@ class LogVisualizer extends React.Component {
             chartSize={chartSize}
             isResultNameAlignRight={isResultNameAlignRight}
             onResultSelect={onResultSelect}
+            onAxisConfigLineUpdate={onAxisConfigLineUpdate}
           />
         </div>
       ) : null;

--- a/frontend/src/components/LogVisualizer.jsx
+++ b/frontend/src/components/LogVisualizer.jsx
@@ -63,7 +63,7 @@ class LogVisualizer extends React.Component {
       projectConfig,
       globalConfig,
       onResultSelect,
-      onAxisConfigLogKeySelectToggle,
+      onAxisConfigLineUpdate,
       stats
     } = this.props;
     const { resultsStatus = {} } = projectStatus;
@@ -99,7 +99,7 @@ class LogVisualizer extends React.Component {
           chartSize={chartSize}
           isResultNameAlignRight={isResultNameAlignRight}
           onResultSelect={onResultSelect}
-          onAxisConfigLogKeySelectToggle={onAxisConfigLogKeySelectToggle}
+          onAxisConfigLineUpdate={onAxisConfigLineUpdate}
         />
         <Button size="sm" className="m-1" onClick={this.handleClickDownloadCode}>
           <span className="mx-1 oi oi-data-transfer-download" />code
@@ -121,7 +121,7 @@ LogVisualizer.propTypes = {
   globalConfig: uiPropTypes.globalConfig.isRequired,
   onChartDownloadStatusUpdate: PropTypes.func.isRequired,
   onResultSelect: PropTypes.func.isRequired,
-  onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired
+  onAxisConfigLineUpdate: PropTypes.func.isRequired
 };
 
 export default LogVisualizer;

--- a/frontend/src/components/LogVisualizer.jsx
+++ b/frontend/src/components/LogVisualizer.jsx
@@ -72,6 +72,7 @@ class LogVisualizer extends React.Component {
       (projectStatus.chartDownloadStatus !== CHART_DOWNLOAD_STATUS.NONE) ? (
         <div className="plot-hidden" ref={this.chartRef}>
           <LogVisualizerChart
+            isDisplay={false}
             project={project}
             results={results}
             stats={stats}
@@ -88,6 +89,7 @@ class LogVisualizer extends React.Component {
       <div className="log-visualizer-root">
         {tempHiddenPlot}
         <LogVisualizerChart
+          isDisplay
           project={project}
           results={results}
           stats={stats}

--- a/frontend/src/components/LogVisualizerChart.jsx
+++ b/frontend/src/components/LogVisualizerChart.jsx
@@ -45,7 +45,8 @@ const LogVisualizerChart = (props) => {
     resultsStatus,
     chartSize,
     isResultNameAlignRight,
-    onResultSelect
+    onResultSelect,
+    onAxisConfigLogKeySelectToggle
   } = props;
   const { axes, resultsConfig, lines } = projectConfig;
   const { logKeys, xAxisKeys } = stats;
@@ -174,6 +175,7 @@ const LogVisualizerChart = (props) => {
           maxHeight={chartSize.height}
           isResultNameAlignRight={isResultNameAlignRight}
           onResultSelect={onResultSelect}
+          onAxisConfigLogKeySelectToggle={onAxisConfigLogKeySelectToggle}
         />
       </div>
     </div>
@@ -189,7 +191,8 @@ LogVisualizerChart.propTypes = {
   resultsStatus: uiPropTypes.resultsStatus.isRequired,
   chartSize: uiPropTypes.chartSize.isRequired,
   isResultNameAlignRight: PropTypes.bool.isRequired,
-  onResultSelect: PropTypes.func.isRequired
+  onResultSelect: PropTypes.func.isRequired,
+  onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired
 };
 
 export default LogVisualizerChart;

--- a/frontend/src/components/LogVisualizerChart.jsx
+++ b/frontend/src/components/LogVisualizerChart.jsx
@@ -37,6 +37,7 @@ const getDomain = (axisConfig = {}) => {
 
 const LogVisualizerChart = (props) => {
   const {
+    isDisplay,
     project,
     results,
     stats,
@@ -164,6 +165,7 @@ const LogVisualizerChart = (props) => {
       </ResponsiveContainer>
       <div>
         <LogVisualizerLegend
+          isDisplay={isDisplay}
           project={project}
           results={results}
           resultsStatus={resultsStatus}
@@ -178,6 +180,7 @@ const LogVisualizerChart = (props) => {
 };
 
 LogVisualizerChart.propTypes = {
+  isDisplay: PropTypes.bool.isRequired,
   project: uiPropTypes.project.isRequired,
   results: uiPropTypes.results.isRequired,
   stats: uiPropTypes.stats.isRequired,

--- a/frontend/src/components/LogVisualizerChart.jsx
+++ b/frontend/src/components/LogVisualizerChart.jsx
@@ -46,7 +46,7 @@ const LogVisualizerChart = (props) => {
     chartSize,
     isResultNameAlignRight,
     onResultSelect,
-    onAxisConfigLogKeySelectToggle
+    onAxisConfigLineUpdate
   } = props;
   const { axes, resultsConfig, lines } = projectConfig;
   const { logKeys, xAxisKeys } = stats;
@@ -175,7 +175,7 @@ const LogVisualizerChart = (props) => {
           maxHeight={chartSize.height}
           isResultNameAlignRight={isResultNameAlignRight}
           onResultSelect={onResultSelect}
-          onAxisConfigLogKeySelectToggle={onAxisConfigLogKeySelectToggle}
+          onAxisConfigLineUpdate={onAxisConfigLineUpdate}
         />
       </div>
     </div>
@@ -192,7 +192,7 @@ LogVisualizerChart.propTypes = {
   chartSize: uiPropTypes.chartSize.isRequired,
   isResultNameAlignRight: PropTypes.bool.isRequired,
   onResultSelect: PropTypes.func.isRequired,
-  onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired
+  onAxisConfigLineUpdate: PropTypes.func.isRequired
 };
 
 export default LogVisualizerChart;

--- a/frontend/src/components/LogVisualizerChart.jsx
+++ b/frontend/src/components/LogVisualizerChart.jsx
@@ -75,9 +75,7 @@ const LogVisualizerChart = (props) => {
       selectedLogKeys[axisName].forEach((logKey) => {
         const line = lines[line2key({ resultId, logKey })] ||
                 createLine(resultId, logKey, results, logKeys);
-        if (line.config.isVisible) {
-          axisLines[axisName].push(line);
-        }
+        axisLines[axisName].push(line);
       });
     });
   });
@@ -90,6 +88,9 @@ const LogVisualizerChart = (props) => {
   const lineElems = [];
   Object.keys(axisLines).forEach((axisName) => {
     axisLines[axisName].forEach((line) => {
+      if (!line.config.isVisible) {
+        return;
+      }
       const { config = {}, resultId, logKey } = line;
       const resultStatus = resultsStatus[resultId] || {};
       const selected = resultStatus.selected === true || resultStatus.selected === logKey;

--- a/frontend/src/components/LogVisualizerLegend.jsx
+++ b/frontend/src/components/LogVisualizerLegend.jsx
@@ -11,7 +11,7 @@ import {
 const LogVisualizerLegendItem = (props) => {
   const {
     isDisplay, project, result, resultStatus, axisName, line, isResultNameAlignRight,
-    onResultSelect, onAxisConfigLogKeySelectToggle
+    onResultSelect, onAxisConfigLineUpdate
   } = props;
   const { logKey, config } = line;
   const selected = resultStatus.selected === true || resultStatus.selected === logKey;
@@ -34,7 +34,7 @@ const LogVisualizerLegendItem = (props) => {
               <Input
                 type="checkbox"
                 checked={line.config.isVisible}
-                onChange={() => onAxisConfigLogKeySelectToggle(project.id, axisName, logKey)}
+                onChange={() => onAxisConfigLineUpdate(project.id, axisName, logKey, line)}
               />
             </FormGroup>
           </Col>
@@ -63,7 +63,7 @@ LogVisualizerLegendItem.propTypes = {
   line: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
   isResultNameAlignRight: PropTypes.bool.isRequired,
   onResultSelect: PropTypes.func.isRequired,
-  onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired
+  onAxisConfigLineUpdate: PropTypes.func.isRequired
 };
 
 LogVisualizerLegendItem.defaultProps = {
@@ -75,7 +75,7 @@ const LogVisualizerLegend = (props) => {
   const {
     isDisplay,
     project, results, resultsStatus, lines, maxHeight, isResultNameAlignRight,
-    onResultSelect, onAxisConfigLogKeySelectToggle
+    onResultSelect, onAxisConfigLineUpdate
   } = props;
 
   return (
@@ -94,7 +94,7 @@ const LogVisualizerLegend = (props) => {
                 line={line}
                 isResultNameAlignRight={isResultNameAlignRight}
                 onResultSelect={onResultSelect}
-                onAxisConfigLogKeySelectToggle={onAxisConfigLogKeySelectToggle}
+                onAxisConfigLineUpdate={onAxisConfigLineUpdate}
               />
             ))
           ))}
@@ -113,7 +113,7 @@ LogVisualizerLegend.propTypes = {
   maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   isResultNameAlignRight: PropTypes.bool.isRequired,
   onResultSelect: PropTypes.func.isRequired,
-  onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired
+  onAxisConfigLineUpdate: PropTypes.func.isRequired
 };
 
 export default LogVisualizerLegend;

--- a/frontend/src/components/LogVisualizerLegend.jsx
+++ b/frontend/src/components/LogVisualizerLegend.jsx
@@ -10,10 +10,12 @@ import {
 
 const LogVisualizerLegendItem = (props) => {
   const {
-    isDisplay, project, result, resultStatus, line, isResultNameAlignRight, onResultSelect
+    isDisplay, project, result, resultStatus, axisName, line, isResultNameAlignRight,
+    onResultSelect, onAxisConfigLogKeySelectToggle
   } = props;
   const { logKey, config } = line;
   const selected = resultStatus.selected === true || resultStatus.selected === logKey;
+
   return (
     <li
       className={`list-group-item py-0 ${selected ? 'result-highlight' : ''}`}
@@ -29,7 +31,11 @@ const LogVisualizerLegendItem = (props) => {
         { isDisplay ? (
           <Col xs="auto" className="px-1">
             <FormGroup check>
-              <Input type="checkbox" />
+              <Input
+                type="checkbox"
+                checked={line.config.isVisible}
+                onChange={() => onAxisConfigLogKeySelectToggle(project.id, axisName, logKey)}
+              />
             </FormGroup>
           </Col>
         ) : null}
@@ -53,9 +59,11 @@ LogVisualizerLegendItem.propTypes = {
   project: uiPropTypes.project.isRequired,
   result: uiPropTypes.result,
   resultStatus: uiPropTypes.resultStatus,
+  axisName: uiPropTypes.axisName.isRequired,
   line: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
   isResultNameAlignRight: PropTypes.bool.isRequired,
-  onResultSelect: PropTypes.func.isRequired
+  onResultSelect: PropTypes.func.isRequired,
+  onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired
 };
 
 LogVisualizerLegendItem.defaultProps = {
@@ -66,7 +74,8 @@ LogVisualizerLegendItem.defaultProps = {
 const LogVisualizerLegend = (props) => {
   const {
     isDisplay,
-    project, results, resultsStatus, lines, maxHeight, isResultNameAlignRight, onResultSelect
+    project, results, resultsStatus, lines, maxHeight, isResultNameAlignRight,
+    onResultSelect, onAxisConfigLogKeySelectToggle
   } = props;
 
   return (
@@ -81,9 +90,11 @@ const LogVisualizerLegend = (props) => {
                 project={project}
                 result={results[line.resultId]}
                 resultStatus={resultsStatus[line.resultId]}
+                axisName={axisName}
                 line={line}
                 isResultNameAlignRight={isResultNameAlignRight}
                 onResultSelect={onResultSelect}
+                onAxisConfigLogKeySelectToggle={onAxisConfigLogKeySelectToggle}
               />
             ))
           ))}
@@ -101,7 +112,8 @@ LogVisualizerLegend.propTypes = {
   lines: PropTypes.objectOf(PropTypes.any).isRequired,
   maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   isResultNameAlignRight: PropTypes.bool.isRequired,
-  onResultSelect: PropTypes.func.isRequired
+  onResultSelect: PropTypes.func.isRequired,
+  onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired
 };
 
 export default LogVisualizerLegend;

--- a/frontend/src/components/LogVisualizerLegend.jsx
+++ b/frontend/src/components/LogVisualizerLegend.jsx
@@ -39,6 +39,11 @@ class LogVisualizerLegendItem extends React.Component {
     const { logKey, config } = line;
     const selected = resultStatus.selected === true || resultStatus.selected === logKey;
 
+    if (!isDisplay && !line.config.isVisible) {
+      // do not inclue rows for invisible lines when rendering for png download
+      return null;
+    }
+
     return (
       <li
         className={`list-group-item py-0 ${selected ? 'result-highlight' : ''}`}
@@ -129,7 +134,7 @@ const LogVisualizerLegend = (props) => {
 };
 
 LogVisualizerLegend.propTypes = {
-  isDisplay: PropTypes.bool.isRequired,
+  isDisplay: PropTypes.bool.isRequired, // false when rendering for png download
   project: uiPropTypes.project.isRequired,
   results: uiPropTypes.results.isRequired,
   resultsStatus: uiPropTypes.resultsStatus.isRequired,

--- a/frontend/src/components/LogVisualizerLegend.jsx
+++ b/frontend/src/components/LogVisualizerLegend.jsx
@@ -5,54 +5,78 @@ import { Row, Col, Input, FormGroup } from 'reactstrap';
 import * as uiPropTypes from '../store/uiPropTypes';
 import TruncatedResultName from './TruncatedResultName';
 import {
+  line2key,
   line2dataKey
 } from '../utils';
 
-const LogVisualizerLegendItem = (props) => {
-  const {
-    isDisplay, project, result, resultStatus, axisName, line, isResultNameAlignRight,
-    onResultSelect, onAxisConfigLineUpdate
-  } = props;
-  const { logKey, config } = line;
-  const selected = resultStatus.selected === true || resultStatus.selected === logKey;
+class LogVisualizerLegendItem extends React.Component {
+  constructor(props) {
+    super(props);
 
-  return (
-    <li
-      className={`list-group-item py-0 ${selected ? 'result-highlight' : ''}`}
-      style={{ borderLeft: `3px solid ${config.color}` }}
-      onMouseEnter={() => {
-        onResultSelect(project.id, result.id, logKey);
-      }}
-      onMouseLeave={() => {
-        onResultSelect(project.id, result.id, false);
-      }}
-    >
-      <Row>
-        { isDisplay ? (
-          <Col xs="auto" className="px-1">
-            <FormGroup check>
-              <Input
-                type="checkbox"
-                checked={line.config.isVisible}
-                onChange={() => onAxisConfigLineUpdate(project.id, axisName, logKey, line)}
-              />
-            </FormGroup>
+    this.handleLineVisibilityUpdate = this.handleLineVisibilityUpdate.bind(this);
+  }
+
+  handleLineVisibilityUpdate(e) {
+    const { project, axisName, line, onAxisConfigLineUpdate } = this.props;
+    const { config } = line;
+    const { checked } = e.target;
+    const newLine = {
+      ...line,
+      config: {
+        ...config,
+        isVisible: checked
+      }
+    };
+
+    onAxisConfigLineUpdate(project.id, axisName, line2key(line), newLine);
+  }
+
+  render() {
+    const {
+      isDisplay, project, result, resultStatus, line, isResultNameAlignRight,
+      onResultSelect
+    } = this.props;
+    const { logKey, config } = line;
+    const selected = resultStatus.selected === true || resultStatus.selected === logKey;
+
+    return (
+      <li
+        className={`list-group-item py-0 ${selected ? 'result-highlight' : ''}`}
+        style={{ borderLeft: `3px solid ${config.color}` }}
+        onMouseEnter={() => {
+          onResultSelect(project.id, result.id, logKey);
+        }}
+        onMouseLeave={() => {
+          onResultSelect(project.id, result.id, false);
+        }}
+      >
+        <Row>
+          { isDisplay ? (
+            <Col xs="auto" className="px-1">
+              <FormGroup check>
+                <Input
+                  type="checkbox"
+                  checked={line.config.isVisible}
+                  onChange={this.handleLineVisibilityUpdate}
+                />
+              </FormGroup>
+            </Col>
+          ) : null}
+          <Col className="text-truncate px-1">
+            <TruncatedResultName
+              project={project}
+              result={result}
+              isResultNameAlignRight={isResultNameAlignRight}
+            />
           </Col>
-        ) : null}
-        <Col className="text-truncate px-1">
-          <TruncatedResultName
-            project={project}
-            result={result}
-            isResultNameAlignRight={isResultNameAlignRight}
-          />
-        </Col>
-        <Col className="text-truncate px-1">
-          {logKey}
-        </Col>
-      </Row>
-    </li>
-  );
-};
+          <Col className="text-truncate px-1">
+            {logKey}
+          </Col>
+        </Row>
+      </li>
+    );
+  }
+}
 
 LogVisualizerLegendItem.propTypes = {
   isDisplay: PropTypes.bool.isRequired,

--- a/frontend/src/components/LogVisualizerLegend.jsx
+++ b/frontend/src/components/LogVisualizerLegend.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// import { Row, Col, FormGroup, Label, Input } from 'reactstrap';
 import { Row, Col, Input, FormGroup } from 'reactstrap';
 
 import * as uiPropTypes from '../store/uiPropTypes';

--- a/frontend/src/components/LogVisualizerLegend.jsx
+++ b/frontend/src/components/LogVisualizerLegend.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'reactstrap';
+// import { Row, Col, FormGroup, Label, Input } from 'reactstrap';
+import { Row, Col, Input, FormGroup } from 'reactstrap';
 
 import * as uiPropTypes from '../store/uiPropTypes';
 import TruncatedResultName from './TruncatedResultName';
@@ -9,7 +10,9 @@ import {
 } from '../utils';
 
 const LogVisualizerLegendItem = (props) => {
-  const { project, result, resultStatus, line, isResultNameAlignRight, onResultSelect } = props;
+  const {
+    isDisplay, project, result, resultStatus, line, isResultNameAlignRight, onResultSelect
+  } = props;
   const { logKey, config } = line;
   const selected = resultStatus.selected === true || resultStatus.selected === logKey;
   return (
@@ -24,14 +27,21 @@ const LogVisualizerLegendItem = (props) => {
       }}
     >
       <Row>
-        <Col xs="6" className="text-truncate px-1">
+        { isDisplay ? (
+          <Col xs="auto" className="px-1">
+            <FormGroup check>
+              <Input type="checkbox" />
+            </FormGroup>
+          </Col>
+        ) : null}
+        <Col className="text-truncate px-1">
           <TruncatedResultName
             project={project}
             result={result}
             isResultNameAlignRight={isResultNameAlignRight}
           />
         </Col>
-        <Col xs="6" className="text-truncate px-1">
+        <Col className="text-truncate px-1">
           {logKey}
         </Col>
       </Row>
@@ -40,6 +50,7 @@ const LogVisualizerLegendItem = (props) => {
 };
 
 LogVisualizerLegendItem.propTypes = {
+  isDisplay: PropTypes.bool.isRequired,
   project: uiPropTypes.project.isRequired,
   result: uiPropTypes.result,
   resultStatus: uiPropTypes.resultStatus,
@@ -55,6 +66,7 @@ LogVisualizerLegendItem.defaultProps = {
 
 const LogVisualizerLegend = (props) => {
   const {
+    isDisplay,
     project, results, resultsStatus, lines, maxHeight, isResultNameAlignRight, onResultSelect
   } = props;
 
@@ -65,6 +77,7 @@ const LogVisualizerLegend = (props) => {
           {Object.keys(lines).flatMap((axisName) => (
             lines[axisName].map((line) => (
               <LogVisualizerLegendItem
+                isDisplay={isDisplay}
                 key={line2dataKey(line, axisName)}
                 project={project}
                 result={results[line.resultId]}
@@ -82,6 +95,7 @@ const LogVisualizerLegend = (props) => {
 };
 
 LogVisualizerLegend.propTypes = {
+  isDisplay: PropTypes.bool.isRequired,
   project: uiPropTypes.project.isRequired,
   results: uiPropTypes.results.isRequired,
   resultsStatus: uiPropTypes.resultsStatus.isRequired,

--- a/frontend/src/containers/PlotContainer.jsx
+++ b/frontend/src/containers/PlotContainer.jsx
@@ -118,6 +118,7 @@ class PlotContainer extends React.Component {
                 globalConfig={globalConfig}
                 onChartDownloadStatusUpdate={this.props.updateChartDownloadStatus}
                 onResultSelect={this.props.updateResultSelect}
+                onAxisConfigLogKeySelectToggle={this.props.toggleLogKeySelect}
               />
               <ExperimentsTable
                 project={project}

--- a/frontend/src/containers/PlotContainer.jsx
+++ b/frontend/src/containers/PlotContainer.jsx
@@ -118,7 +118,7 @@ class PlotContainer extends React.Component {
                 globalConfig={globalConfig}
                 onChartDownloadStatusUpdate={this.props.updateChartDownloadStatus}
                 onResultSelect={this.props.updateResultSelect}
-                onAxisConfigLogKeySelectToggle={this.props.toggleLogKeySelect}
+                onAxisConfigLineUpdate={this.props.updateLineInAxis}
               />
               <ExperimentsTable
                 project={project}


### PR DESCRIPTION
This PR adds checkboxes to `LogVisualizerLegend` .
Using these checkboxes, `LogVisualizerLegend` will take over the features that `LinesConfigurator` in the sidebar currently has.

WIP screenshot

![screen shot 2018-12-18 at 10 17 29](https://user-images.githubusercontent.com/17793678/50126005-8296d980-02ae-11e9-87f0-7ffd0b8de870.png)