### PR TITLE
Add plain install job on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,24 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
+
+matrix:
+  include:
+    - name: "Ubuntu14.04 Py27"
+      dist: trusty
+      python: "2.7"
+    - name: "Ubuntu16.04 Py35"
+      dist: xenial
+      python: "3.5"
+    - name: "Ubuntu16.04 Py36, plain install"
+      dist: xenial
+      python: "3.6"
+      env:
+        - CHAINERUI_PLAIN_INSTALL=1
+    - name: "Ubuntu16.04 Py36"
+      dist: xenial
+      python: "3.6"
+      env:
+        - CHAINERUI_COVERAGE_REPORT=1
+        - CHAINERUI_DEPLOY_JOB=1
 
 services:
   - docker
@@ -15,7 +31,7 @@ sudo: false
 before_install:
   - pip install autopep8 hacking
   - pip install -U pytest pytest-cov coveralls
-  - pip install Pillow matplotlib scipy chainer
+  - if [[ $CHAINERUI_PLAIN_INSTALL != 1 ]]; then pip install Pillow matplotlib scipy chainer; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install mock; fi
   - npm install -g npm@6
   - npm -v
@@ -43,7 +59,7 @@ script:
   - pytest --cov=chainerui
 
 after_success:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then COVERALLS_TOKEN=$COVERALLS_TOKEN coveralls; fi
+  - if [[ $CHAINERUI_COVERAGE_REPORT == 1 ]]; then COVERALLS_TOKEN=$COVERALLS_TOKEN coveralls; fi
 
 deploy:
   - provider: pypi
@@ -51,13 +67,13 @@ deploy:
     password: $PYPI_MAINTAINER_PASS
     on:
       tags: true
-      python: 3.6
+      condition: $CHAINERUI_DEPLOY_JOB == 1
     allow_failure: false
     skip_cleanup: true
   - provider: script
     script: bash .travis/docker_push.sh
     on:
       tags: true
-      python: 3.6
+      condition: $CHAINERUI_DEPLOY_JOB == 1
     allow_failure: false
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ install:
 script:
   # python style check
   - flake8
-  - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
-  - test ! -s check_autopep8
+  - autopep8 -r . --global-config .pep8 --diff --exit-code
   # frontend style check
   - pushd frontend
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ sudo: false
 before_install:
   - pip install autopep8 hacking
   - pip install -U pytest pytest-cov coveralls
-  - if [[ $CHAINERUI_PLAIN_INSTALL != 1 ]]; then pip install Pillow matplotlib scipy chainer; fi
+  - if [[ $CHAINERUI_PLAIN_INSTALL != 1 ]]; then pip install Pillow matplotlib scipy chainer; else pip install numpy; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install mock; fi
   - npm install -g npm@6
   - npm -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - pip --version
 
   - pip install -U pytest pytest-cov mock
-  - if not "%CHAINERUI_PLAIN_INSTALL%"=="1" (pip install Pillow matplotlib scipy chainer)
+  - if "%CHAINERUI_PLAIN_INSTALL%"=="1" (pip install numpy) else (pip install Pillow matplotlib scipy chainer)
 
   # Update Node.js
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+      CHAINERUI_PLAIN_INSTALL: 1
+    - PYTHON: "C:\\Python36-x64"
 
 install:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
@@ -12,7 +14,7 @@ install:
   - pip --version
 
   - pip install -U pytest pytest-cov mock
-  - pip install Pillow matplotlib scipy chainer
+  - if not "%CHAINERUI_PLAIN_INSTALL%"=="1" (pip install Pillow matplotlib scipy chainer)
 
   # Update Node.js
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
Currently CI job installs Pillow, scipy and other modules for test. To check run ChainerUI on an environment whith installs only required modules, add "Plain install" job.