### PR TITLE
Use React.memo for AxesConfigurator

### DIFF
--- a/frontend/src/components/AxesConfigurator.jsx
+++ b/frontend/src/components/AxesConfigurator.jsx
@@ -116,4 +116,4 @@ AxesConfigurator.propTypes = {
   onAxisConfigLogKeySelectToggle: PropTypes.func.isRequired,
 };
 
-export default AxesConfigurator;
+export default React.memo(AxesConfigurator);


### PR DESCRIPTION
This PR aims to make rendering on a browser faster by using `React.memo` .
The profiler results below show the difference of rendering time between with and without `React.memo` for `AxesConfigurator` when hovering the mouse over the legend.

**before**
![image4](https://user-images.githubusercontent.com/17793678/53472419-e0b01c00-3aaa-11e9-8e64-58728833a161.png)

**after**
![image3](https://user-images.githubusercontent.com/17793678/53472435-e4dc3980-3aaa-11e9-928a-94423b4c10fa.png)
