### PR TITLE
Disable tooltip in png

### DIFF
--- a/frontend/src/components/LogVisualizerChart.jsx
+++ b/frontend/src/components/LogVisualizerChart.jsx
@@ -165,9 +165,13 @@ const LogVisualizerChart = (props) => {
           />
           <CartesianGrid strokeDasharray="3 3" />
           {lineElems}
-          <Tooltip
-            content={<LogVisualizerTooltip xAxisKey={xAxisKey} anySelected={anySelected} />}
-          />
+          {isDisplay
+            ? (
+              <Tooltip
+                content={<LogVisualizerTooltip xAxisKey={xAxisKey} anySelected={anySelected} />}
+              />
+            ) : null // disable tooltip when rendering for png
+          }
         </LineChart>
       </ResponsiveContainer>
       <div>


### PR DESCRIPTION
Tooltip is not needed when rendering for png download.
This PR disables tooltip in that case.