### PR TITLE
Tweaked removePartialState

### DIFF
--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -24,7 +24,7 @@ const removePartialState = (state, keyId) => {
   if (keyId in state) {
     const newState = { ...state };
     delete newState[keyId];
-    return state;
+    return newState;
   }
   return state;
 };


### PR DESCRIPTION
`removePartialState` will always return the raw state.
I expected it return the tweaked state.