### PR TITLE
Introduce "test-ci" install mode on setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
   - npm install && npm run build -- --progress=false --profile=false
   - popd
   - pip install -e .$CHAINERUI_TEST_DEPENDS
+  - pip list -v
 
 script:
   # python style check

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,12 @@ notifications:
 sudo: false
 
 before_install:
-  - pip install autopep8 hacking
-  - pip install -U pytest pytest-cov coveralls
-  - if [[ $CHAINERUI_PLAIN_INSTALL != 1 ]]; then pip install Pillow matplotlib scipy chainer; else pip install numpy; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install mock; fi
+  - |
+    if [[ $CHAINERUI_PLAIN_INSTALL == 1 ]]; then
+      export CHAINERUI_TEST_DEPENDS="[test-ci-plain]";
+    else
+      export CHAINERUI_TEST_DEPENDS="[test-ci]";
+    fi
   - npm install -g npm@6
   - npm -v
 
@@ -40,7 +42,7 @@ install:
   - pushd frontend
   - npm install && npm run build -- --progress=false --profile=false
   - popd
-  - pip install -e .
+  - pip install -e .$CHAINERUI_TEST_DEPENDS
 
 script:
   # python style check

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,12 @@ install:
   - python --version
   - pip --version
 
-  - pip install -U pytest pytest-cov mock
-  - if "%CHAINERUI_PLAIN_INSTALL%"=="1" (pip install numpy) else (pip install Pillow matplotlib scipy chainer)
+  - |
+    if "%CHAINERUI_PLAIN_INSTALL%"=="1" (
+      set CHAINERUI_TEST_DEPENDS="[test-ci-plain]"
+    ) else (
+      set CHAINERUI_TEST_DEPENDS="[test-ci]"
+    )
 
   # Update Node.js
   - ps: Install-Product node $env:nodejs_version
@@ -27,7 +31,7 @@ build_script:
   - npm install
   - npm run build -- --progress=false --profile=false
   - cd ..
-  - pip install -e .
+  - pip install -e .%CHAINERUI_TEST_DEPENDS%
 
   # Server connection test
   - chainerui db create

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,7 @@ install:
   - python --version
   - pip --version
 
-  - |
-    if "%CHAINERUI_PLAIN_INSTALL%"=="1" (
-      set CHAINERUI_TEST_DEPENDS="[test-ci-plain]"
-    ) else (
-      set CHAINERUI_TEST_DEPENDS="[test-ci]"
-    )
+  - if "%CHAINERUI_PLAIN_INSTALL%"=="1" (set CHAINERUI_TEST_DEPENDS="[test-ci-plain]") else (set CHAINERUI_TEST_DEPENDS="[test-ci]")
 
   # Update Node.js
   - ps: Install-Product node $env:nodejs_version
@@ -32,6 +27,7 @@ build_script:
   - npm run build -- --progress=false --profile=false
   - cd ..
   - pip install -e .%CHAINERUI_TEST_DEPENDS%
+  - pip list -v
 
   # Server connection test
   - chainerui db create

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = {
     ],
     'test': [
         'numpy',
-        'pytest<5.0.0',
+        'pytest>=4.0.0,<5.0.0',
         'mock',
     ],
     'test-ci-plain': [

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,59 @@ from setuptools import find_packages
 from setuptools import setup
 import subprocess
 
+
 with open('requirements.txt') as f:
     required = f.read().splitlines()
 
 
 with open(os.path.join('docs', 'requirements.txt')) as f:
     docs_required = f.read().splitlines()
+
+
+requirements = {
+    'install': required,
+    'docs': docs_required,
+    'stylecheck': [
+        'autopep8',
+        'hacking',
+    ],
+    'test': [
+        'numpy',
+        'pytest<5.0.0',
+        'mock',
+    ],
+    'test-ci-plain': [
+        '-r stylecheck',
+        '-r test',
+        'pytest-cov',
+        'coveralls',
+    ],
+    'test-ci': [
+        '-r test-ci-plain',
+        'Pillow',
+        'matplotlib',
+        'scipy',
+        'chainer',
+    ]
+}
+
+
+def reduce_requirements(key):
+    # Resolve recursive requirements notation (-r)
+    reqs = requirements[key]
+    resolved_reqs = []
+    for req in reqs:
+        if req.startswith('-r'):
+            depend_key = req[2:].lstrip()
+            reduce_requirements(depend_key)
+            resolved_reqs += requirements[depend_key]
+        else:
+            resolved_reqs.append(req)
+    requirements[key] = resolved_reqs
+
+
+for k in requirements.keys():
+    reduce_requirements(k)
 
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -30,8 +77,9 @@ setup(
     description='ChainerUI: User Interface for Chainer',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    install_requires=required,
-    extras_require={'docs': docs_required},
+    install_requires=requirements['install'],
+    tests_require=requirements['test'],
+    extras_require={k: v for k, v in requirements.items() if k != 'install'},
     package_data={
         'chainerui': [
             'templates/*',
@@ -47,7 +95,6 @@ setup(
             "chainerui=chainerui.app:main",
         ]
     },
-    tests_require=['pytest'],
     cmdclass={
         'sdist': chainerui_sdist
     },

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 from string import Template
@@ -36,7 +37,7 @@ def _get_script_path(dir, rendered_log):
 
     script = script_tmpl.substitute(rendered_log=rendered_log)
     script_path = os.path.join(dir, 'render.py')
-    with open(script_path, 'w', newline='\n') as f:
+    with io.open(script_path, 'w', newline='\n') as f:
         f.write(script)
 
     return script_path

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -32,12 +32,12 @@ def _get_script_path(dir, rendered_log):
         current_dir, '..', 'frontend', 'src', 'utils', 'render.py.tmpl'))
     assert os.path.exists(render_tmp_path)
 
-    with open(render_tmp_path) as f:
+    with io.open(render_tmp_path, encoding='utf-8') as f:
         script_tmpl = Template(f.read())
 
     script = script_tmpl.substitute(rendered_log=rendered_log)
     script_path = os.path.join(dir, 'render.py')
-    with io.open(script_path, 'w', newline='\n') as f:
+    with io.open(script_path, 'w', newline='\n', encoding='utf-8') as f:
         f.write(script)
 
     return script_path

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -36,7 +36,7 @@ def _get_script_path(dir, rendered_log):
 
     script = script_tmpl.substitute(rendered_log=rendered_log)
     script_path = os.path.join(dir, 'render.py')
-    with open(script_path, 'w') as f:
+    with open(script_path, 'w', newline='\n') as f:
         f.write(script)
 
     return script_path


### PR DESCRIPTION
fixes #303 

To control all dependent versions on setup.py

From this PR, windows tests has `flake8` module and need to pass rendering test both win and linux, py36 and py27. Modification is included on this PR.