### PR TITLE
Support send log without Trainer

### DIFF
--- a/chainerui/__init__.py
+++ b/chainerui/__init__.py
@@ -1,5 +1,6 @@
 from chainerui import _version
 from chainerui.client.client import init  # NOQA
+from chainerui.client.client import log  # NOQA
 from chainerui.client.client import log_reporter  # NOQA
 
 

--- a/chainerui/client/client.py
+++ b/chainerui/client/client.py
@@ -313,3 +313,26 @@ def log_reporter():
             _client.post_log([stats_cpu])
 
     return PostProcess()
+
+
+def log(value):
+    """Send log
+
+    Send log data and will be shown ad training log on web browser.
+
+    Example::
+
+       >>> chainerui.init()
+       >>> # ...
+       >>> stats = {
+       >>>     'epoch': epoch,
+       >>>     'train/loss': loss,
+       >>>     }
+       >>> chainerui.log(stats)
+
+    Args:
+        value (dict): target log.
+    """
+    if _client is None:
+        return
+    _client.post_log([value])

--- a/tests/client_tests/test_client.py
+++ b/tests/client_tests/test_client.py
@@ -75,8 +75,7 @@ def test_client_init_default(server):
     assert client._client.project_id == 1
     assert client._client.result_id == 1
 
-    reporter = client.log_reporter()
-    reporter({'loss': 0.001})
+    client.log({'loss': 0.001})
 
 
 def test_client_init_with_condition(server):
@@ -100,6 +99,8 @@ def test_client_init_no_server(server):
 
     reporter = client.log_reporter()
     reporter({'loss': 0.001})  # fail to make client but no error
+
+    client.log({'loss': 0.001})  # same
 
 
 class TestClient(object):


### PR DESCRIPTION
add `chainerui.log(value)` to support training script which does not use `Trainer`