### PR TITLE
Add docs requirements to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include chainerui/templates/*
 include chainerui/static/**/*
 include requirements.txt
+include docs/requirements.txt
 include README.md
 include LICENSE


### PR DESCRIPTION
Run `$ python setup.py` then get "chainerui-0.10.0.tar.gz", which does not include "docs/requirements.txt". This causes installing error on `$ pip install chainerui_0.10.0.tar.gz` 

https://travis-ci.org/chainer/chainerui/jobs/567754471