### PR TITLE
Remove redux requests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8232,11 +8232,6 @@
       "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-5.9.1.tgz",
       "integrity": "sha512-WIaLCd975R16W7nD1wqUPLcqeLztIRvsSSNZdblEjtihL1wz+NSOq9nYUSvsdoWJOtfm9RbDF4IVd0a3VOtZcw=="
     },
-    "redux-requests": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/redux-requests/-/redux-requests-1.0.2.tgz",
-      "integrity": "sha1-FIUDnLgjgUVcZ9rnH1SkTv6OB1Y="
-    },
     "redux-thunk": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,6 @@
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
     "redux-persist": "5.9.1",
-    "redux-requests": "^1.0.2",
     "redux-thunk": "2.2.0",
     "whatwg-fetch": "^3.0.0"
   },

--- a/frontend/src/middleware/api.js
+++ b/frontend/src/middleware/api.js
@@ -31,7 +31,7 @@ export const CALL_API = 'Call API';
  * @param  {Function} makeRequest Function that returns a Promise object. This function performs the actual request.
  * @param  {Function} dispatch    Redux store dispatch function.
  */
-export function attemptRequest(url, actions, makeRequest, dispatch) {
+const attemptRequest = (url, actions, makeRequest, dispatch) => {
   const beginAction = { ...actions.begin() };
   beginAction.meta = beginAction.meta || {};
   beginAction.meta.httpRequest = { url, done: false };
@@ -51,7 +51,7 @@ export function attemptRequest(url, actions, makeRequest, dispatch) {
       failureAction.meta.httpRequest = { url, done: true };
       dispatch(failureAction);
     });
-}
+};
 
 export default (store) => (next) => (action) => {
   const callAPI = action[CALL_API];

--- a/frontend/src/middleware/api.js
+++ b/frontend/src/middleware/api.js
@@ -1,5 +1,3 @@
-import { attemptRequest } from 'redux-requests';
-
 const API_ROOT = '/api/v1/';
 
 const callApi = (endpoint, method = 'GET', body) => {
@@ -25,6 +23,35 @@ const callApi = (endpoint, method = 'GET', body) => {
 };
 
 export const CALL_API = 'Call API';
+
+/**
+ * Helper function to attempt a request and handle the response.
+ * @param  {String} url           The URL the request is for.
+ * @param  {Object} actions       Actions to dispatch depending on the outcome of the "makeRequest" Promise.
+ * @param  {Function} makeRequest Function that returns a Promise object. This function performs the actual request.
+ * @param  {Function} dispatch    Redux store dispatch function.
+ */
+export function attemptRequest(url, actions, makeRequest, dispatch) {
+  const beginAction = { ...actions.begin() };
+  beginAction.meta = beginAction.meta || {};
+  beginAction.meta.httpRequest = { url, done: false };
+  if (!dispatch(beginAction)) {
+    return; // bail out here if the middleware cancelled the dispatch
+  }
+  makeRequest()
+    .then((response) => {
+      const successAction = { ...actions.success(response) };
+      successAction.meta = successAction.meta || {};
+      successAction.meta.httpRequest = { url, done: true };
+      dispatch(successAction);
+    })
+    .catch((err) => {
+      const failureAction = { ...actions.failure(err) };
+      failureAction.meta = failureAction.meta || {};
+      failureAction.meta.httpRequest = { url, done: true };
+      dispatch(failureAction);
+    });
+}
 
 export default (store) => (next) => (action) => {
   const callAPI = action[CALL_API];

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -1,7 +1,6 @@
 import { combineReducers } from 'redux';
 import { routerReducer, LOCATION_CHANGE } from 'react-router-redux';
 import { persistReducer } from 'redux-persist';
-import { requestsReducer } from 'redux-requests';
 import storage from 'redux-persist/es/storage';
 import * as ActionTypes from '../actions';
 import {
@@ -13,6 +12,30 @@ import {
   keyOptions,
   fetchResultTypes,
 } from '../constants';
+
+/**
+ * Reducer function to handle pending requests.
+ * @param  {Object} state  Existing state object.
+ * @param  {Object} action Incoming action:
+ *                         - Actions with the meta.httpRequest property are examined.
+ *                         - The meta.httpRequest.url property is added or removed
+ *                           from the current state depending on if the meta.httpRequest.done
+ *                           property is set.
+ * @return {Object}        The new state.
+ */
+export function requestsReducer(state = {}, action) {
+  if (!action.meta || !action.meta.httpRequest || !action.meta.httpRequest.url) {
+    return state;
+  }
+  if (action.meta.httpRequest.done) {
+    // Remove this request from the state
+    const newState = { ...state };
+    delete newState[action.meta.httpRequest.url];
+    return newState;
+  }
+  // Add this request to the state
+  return { ...state, [action.meta.httpRequest.url]: true };
+}
 
 const updatePartialState = (state, action, keyId, fn) => {
   const partialState = fn(state[keyId], action);

--- a/frontend/src/reducers/index.jsx
+++ b/frontend/src/reducers/index.jsx
@@ -23,7 +23,7 @@ import {
  *                           property is set.
  * @return {Object}        The new state.
  */
-export function requestsReducer(state = {}, action) {
+const requestsReducer = (state = {}, action) => {
   if (!action.meta || !action.meta.httpRequest || !action.meta.httpRequest.url) {
     return state;
   }
@@ -35,7 +35,7 @@ export function requestsReducer(state = {}, action) {
   }
   // Add this request to the state
   return { ...state, [action.meta.httpRequest.url]: true };
-}
+};
 
 const updatePartialState = (state, action, keyId, fn) => {
   const partialState = fn(state[keyId], action);

--- a/frontend/src/store/configureStore.js
+++ b/frontend/src/store/configureStore.js
@@ -1,9 +1,31 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import { createRequestMiddleware } from 'redux-requests';
 import { createLogger } from 'redux-logger';
 import api from '../middleware/api';
 import rootReducer from '../reducers';
+
+/**
+ * Creates a Redux middleware function when called.
+ * @param  {Function} selectorFunc A function to select the location in the store's state tree where
+ *                                   the requests reducer keeps it's state.
+ * @return {Function}              A middleware function that will only dispatch the action if the
+ *                                   action.meta.httpRequest.done property is false, and the
+ *                                   meta.httpRequest.url is not already in flight.
+ */
+export function createRequestMiddleware(selectorFunc = (state) => state.requests) {
+  return (store) => (next) => (action) => {
+    // Cancel HTTP request if there is already one pending for this URL
+    if (action.meta && action.meta.httpRequest && !action.meta.httpRequest.done) {
+      const requests = selectorFunc(store.getState());
+      if (requests[action.meta.httpRequest.url]) {
+        // There is a request for this URL in flight already!
+        // (Ignore the action)
+        return undefined;
+      }
+    }
+    return next(action);
+  };
+}
 
 const configureStore = (preloadedState) => {
   const middleware = [thunk, api, createRequestMiddleware(), createLogger()];

--- a/frontend/src/store/configureStore.js
+++ b/frontend/src/store/configureStore.js
@@ -12,7 +12,7 @@ import rootReducer from '../reducers';
  *                                   action.meta.httpRequest.done property is false, and the
  *                                   meta.httpRequest.url is not already in flight.
  */
-export function createRequestMiddleware(selectorFunc = (state) => state.requests) {
+const createRequestMiddleware = (selectorFunc = (state) => state.requests) => {
   return (store) => (next) => (action) => {
     // Cancel HTTP request if there is already one pending for this URL
     if (action.meta && action.meta.httpRequest && !action.meta.httpRequest.done) {
@@ -25,7 +25,7 @@ export function createRequestMiddleware(selectorFunc = (state) => state.requests
     }
     return next(action);
   };
-}
+};
 
 const configureStore = (preloadedState) => {
   const middleware = [thunk, api, createRequestMiddleware(), createLogger()];


### PR DESCRIPTION
This PR removes `redux-requests` from dependency.

To remove `redux-requests`, functions of `redux-requests` was copied to chainerui.
We need to refactor `middleware/api.js` when we re-write it with typescript.