### PR TITLE
Replace babel-polyfill with core-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -741,39 +741,6 @@
         "ast-types-flow": "0.0.7"
       }
     },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1711,9 +1678,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -8166,6 +8133,13 @@
         "react-smooth": "^1.0.0",
         "recharts-scale": "^0.4.2",
         "reduce-css-calc": "^1.3.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        }
       }
     },
     "recharts-scale": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,8 +51,8 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.10.1",
-    "babel-polyfill": "^6.26.0",
     "bootstrap": "^4.3.1",
+    "core-js": "^3.2.1",
     "html2canvas": "^1.0.0-rc.3",
     "jquery": "^3.4.1",
     "moment": "^2.24.0",

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -27,7 +27,7 @@ const version = versionMatches[1];
 module.exports = {
   entry: {
     chainerui: [
-      'babel-polyfill',
+      'core-js/es',
       'whatwg-fetch',
       'bootstrap/dist/css/bootstrap.css',
       '@fortawesome/fontawesome-free/css/all.css',


### PR DESCRIPTION
This PR replaces `babel-polyfill` with `core-js`.