### PR TITLE
Reduce py2 test menu on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - name: "Ubuntu14.04 Py27"
       dist: trusty
       python: "2.7"
+      env:
+        - CHAINERUI_PLAIN_INSTALL=1
     - name: "Ubuntu16.04 Py35"
       dist: xenial
       python: "3.5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python27-x64"
+      CHAINERUI_PLAIN_INSTALL: 1
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"


### PR DESCRIPTION
On python2, run simple test which tests with only plain chainerui, not included modules depended on Scipy, Pillow, Chainer. 

Most library have stopped supporting Python2, so this PR catches it up, but currently not stop CI.