### PR TITLE
Feature/tweaked filter row of results table

### DIFF
--- a/frontend/src/components/ExperimentsTable.jsx
+++ b/frontend/src/components/ExperimentsTable.jsx
@@ -94,6 +94,7 @@ const ExperimentsTable = (props) => {
       },
       sortable: false,
       minWidth: 40,
+      filterable: false,
       Aggregated: (row) => {
         const groupedResults = row.subRows.map((r) => {
           const { _original } = r;

--- a/frontend/src/components/experiments_table_cell/ResultFilter.jsx
+++ b/frontend/src/components/experiments_table_cell/ResultFilter.jsx
@@ -12,7 +12,7 @@ const ResultFilter = ({ projectId, filterKey, filterText, onResultFilterUpdate }
   return (
     <div>
       <input
-        className='form-control'
+        className="form-control"
         type="text"
         placeholder={`filter ${filterKey}`}
         value={filterText}

--- a/frontend/src/components/experiments_table_cell/ResultFilter.jsx
+++ b/frontend/src/components/experiments_table_cell/ResultFilter.jsx
@@ -12,6 +12,7 @@ const ResultFilter = ({ projectId, filterKey, filterText, onResultFilterUpdate }
   return (
     <div>
       <input
+        className='form-control'
         type="text"
         placeholder={`filter ${filterKey}`}
         value={filterText}


### PR DESCRIPTION
I tweaked the layout of filter row of results table. Changes are as follows:
- (1) Disable filterable option of the result check column
- (2) Added `form-control` to the class list of result filter component


before:
![スクリーンショット 2019-10-28 12 11 38](https://user-images.githubusercontent.com/4876459/67649363-2267ce00-f97c-11e9-8c95-a471982a4de3.png)

after:
![スクリーンショット 2019-10-28 12 08 41](https://user-images.githubusercontent.com/4876459/67649333-02380f00-f97c-11e9-9238-d03ef35f97af.png)