### PR TITLE
use redux v4

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8214,9 +8214,9 @@
       }
     },
     "redux-persist": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-5.9.1.tgz",
-      "integrity": "sha512-WIaLCd975R16W7nD1wqUPLcqeLztIRvsSSNZdblEjtihL1wz+NSOq9nYUSvsdoWJOtfm9RbDF4IVd0a3VOtZcw=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
     },
     "redux-thunk": {
       "version": "2.3.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8219,9 +8219,9 @@
       "integrity": "sha512-WIaLCd975R16W7nD1wqUPLcqeLztIRvsSSNZdblEjtihL1wz+NSOq9nYUSvsdoWJOtfm9RbDF4IVd0a3VOtZcw=="
     },
     "redux-thunk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-      "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "regenerator-runtime": {
       "version": "0.13.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5590,11 +5590,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -8202,14 +8197,12 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "redux-logger": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,7 @@
     "recharts": "^1.7.1",
     "redux": "^4.0.4",
     "redux-logger": "^3.0.6",
-    "redux-persist": "5.9.1",
+    "redux-persist": "6.0.0",
     "redux-thunk": "2.3.0",
     "whatwg-fetch": "^3.0.0"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "react-table": "^6.10.0",
     "reactstrap": "^8.0.1",
     "recharts": "^1.7.1",
-    "redux": "^3.7.2",
+    "redux": "^4.0.4",
     "redux-logger": "^3.0.6",
     "redux-persist": "5.9.1",
     "redux-thunk": "2.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
     "redux": "^4.0.4",
     "redux-logger": "^3.0.6",
     "redux-persist": "5.9.1",
-    "redux-thunk": "2.2.0",
+    "redux-thunk": "2.3.0",
     "whatwg-fetch": "^3.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
This PR updates redux to v4.
Redux v4 is needed because it has newer type definitions.